### PR TITLE
Fixed incorrect caching in primVarSet and primVarChange

### DIFF
--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -664,9 +664,10 @@ public class Interpreter {
 	}
 
 	protected function primVarSet(b:Block):Variable {
-		var v:Variable = activeThread.target.varCache[arg(b, 0)];
+		var name:String = arg(b, 0);
+		var v:Variable = activeThread.target.varCache[name];
 		if (!v) {
-			v = activeThread.target.varCache[b.spec] = activeThread.target.lookupOrCreateVar(arg(b, 0));
+			v = activeThread.target.varCache[name] = activeThread.target.lookupOrCreateVar(name);
 			if (!v) return null;
 		}
 		var oldvalue:* = v.value;
@@ -675,9 +676,10 @@ public class Interpreter {
 	}
 
 	protected function primVarChange(b:Block):Variable {
-		var v:Variable = activeThread.target.varCache[arg(b, 0)];
+		var name:String = arg(b, 0);
+		var v:Variable = activeThread.target.varCache[name];
 		if (!v) {
-			v = activeThread.target.varCache[b.spec] = activeThread.target.lookupOrCreateVar(arg(b, 0));
+			v = activeThread.target.varCache[name] = activeThread.target.lookupOrCreateVar(name);
 			if (!v) return null;
 		}
 		v.value = Number(v.value) + numarg(b, 1);


### PR DESCRIPTION
Transfer of #161.

Due to a copy-paste error, the SET and CHANGE primitives cache their variable using the wrong key—the spec of the block, either `set %m.var to %s` or `change %m.var by %n`, instead of the variable name. Normally, this isn't noticeable: the only time it causes _incorrect_ behavior is when you have a variable named `set %m.var to %s` or `change %m.var by %n`. However, it makes the SET and CHANGE blocks slower because their caches always miss.
