### PR TITLE
Fixed dragging "when Stage clicked" into a sprite

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -453,7 +453,8 @@ public class Block extends Sprite {
 
 	public function duplicate(forClone:Boolean, forStage:Boolean = false):Block {
 		var newSpec:String = spec;
-		if(forStage && op == 'whenClicked') newSpec = 'when Stage clicked';
+		if (forStage && op == 'whenClicked') newSpec = 'when Stage clicked';
+		if (!forStage && op == 'whenClicked') newSpec = 'when this sprite clicked';
 		var dup:Block = new Block(newSpec, type, (int)(forClone ? -1 : base.color), op);
 		dup.isRequester = isRequester;
 		dup.parameterNames = parameterNames;


### PR DESCRIPTION
If you drag an instance of "when Stage clicked" from the Stage's palette or scripts area into a sprite's thumbnail, the duplicate instance in the sprite keeps the label "when Stage clicked."
