### PR TITLE
Fixed stop block label for "other scripts in sprite/stage"

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -37,12 +37,13 @@ import flash.display.*;
 	import flash.events.*;
 	import flash.filters.GlowFilter;
 	import flash.geom.*;
-import flash.net.URLLoader;
-import flash.text.*;
+	import flash.net.URLLoader;
+	import flash.text.*;
 	import assets.Resources;
 	import translation.Translator;
 	import util.*;
 	import uiwidgets.*;
+	import scratch.ScratchStage;
 
 public class Block extends Sprite {
 
@@ -453,13 +454,21 @@ public class Block extends Sprite {
 
 	public function duplicate(forClone:Boolean, forStage:Boolean = false):Block {
 		var newSpec:String = spec;
-		if(forStage && op == 'whenClicked') newSpec = 'when Stage clicked';
+		if (forStage && op == 'whenClicked') newSpec = 'when Stage clicked';
 		var dup:Block = new Block(newSpec, type, (int)(forClone ? -1 : base.color), op);
 		dup.isRequester = isRequester;
 		dup.parameterNames = parameterNames;
 		dup.defaultArgValues = defaultArgValues;
 		dup.warpProcFlag = warpProcFlag;
-		if (forClone) dup.copyArgsForClone(args); else dup.copyArgs(args);
+		if (forClone) {
+			dup.copyArgsForClone(args);
+		} else {
+			dup.copyArgs(args);
+			if (op == 'stopScripts' && args[0] is BlockArg) {
+				if (forStage && args[0].argValue == 'other scripts in sprite') dup.args[0].setArgValue('other scripts in stage');
+				if (!forStage && args[0].argValue == 'other scripts in stage') dup.args[0].setArgValue('other scripts in sprite');
+			}
+		}
 		if (nextBlock != null) dup.addChild(dup.nextBlock = nextBlock.duplicate(forClone, forStage));
 		if (subStack1 != null) dup.addChild(dup.subStack1 = subStack1.duplicate(forClone, forStage));
 		if (subStack2 != null) dup.addChild(dup.subStack2 = subStack2.duplicate(forClone, forStage));
@@ -749,7 +758,7 @@ public class Block extends Sprite {
 	/* Dragging */
 
 	public function objToGrab(evt:MouseEvent):Block {
-		if (isEmbeddedParameter() || isInPalette()) return duplicate(false);
+		if (isEmbeddedParameter() || isInPalette()) return duplicate(false, Scratch.app.viewedObj() is ScratchStage);
 		return this;
 	}
 

--- a/src/blocks/BlockIO.as
+++ b/src/blocks/BlockIO.as
@@ -93,7 +93,7 @@ public class BlockIO {
 
 		if (cmd[0] == 'getUserName') Scratch.app.usesUserNameBlock = true;
 
-		var special:Block = specialCmd(cmd);
+		var special:Block = specialCmd(cmd, forStage);
 		if (special) { special.fixArgLayout(); return special }
 
 		var b:Block;
@@ -177,7 +177,7 @@ public class BlockIO {
 
 	private static const controlColor:int = Specs.blockColor(Specs.controlCategory);
 
-	private static function specialCmd(cmd:Array):Block {
+	private static function specialCmd(cmd:Array, forStage:Boolean):Block {
 		// If the given command is special (e.g. a reporter or old-style a hat blocK), return a block for it.
 		// Otherwise, return null.
 		var b:Block;
@@ -227,6 +227,8 @@ public class BlockIO {
 		case 'stopScripts':
 			var type:String = (cmd[1].indexOf('other scripts') == 0) ? ' ' : 'f'; // block type depends on menu arg
 			b = new Block('stop %m.stop', type, controlColor, 'stopScripts');
+			if (forStage && b.op == 'stopScripts' && cmd[1] == 'other scripts in sprite') cmd[1] = 'other scripts in stage';
+			if (!forStage && b.op == 'stopScripts' && cmd[1] != 'other scripts in stage') cmd[1] = 'other scripts in sprite';
 			b.setArg(0, cmd[1]);
 			return b;
 		}


### PR DESCRIPTION
…when dragging between a sprite and the stage and between the backpack and a sprite or the stage.

Fixes #131.
