### PR TITLE
Fixed formatting and dispose handling in GIF decoder

### DIFF
--- a/src/util/GIFDecoder.as
+++ b/src/util/GIFDecoder.as
@@ -209,7 +209,7 @@ public class GIFDecoder {
 						// assume background is transparent
 						var c:Number = transparency ? 0x00000000 : lastBgColor;
 						// use given background color
-						bitmap.fillRect(lastRect, c);
+						bitmap.fillRect(bitmap.rect, c);
 					}
 				}
 			}


### PR DESCRIPTION
Part of the GIF decoder was ported incorrectly to ActionScript, which led to incorrect decoding of optimized GIFs (#66). This fixes the (existing) decoder code without breaking for GIFs with dispose-values of 2 or 3 like #181.

Also fixed formatting to use the same conventions as the rest of the source code, which is why the diff is messy. Whitespace-free one: https://github.com/LLK/scratch-flash/pull/190/files?w=1
