### PR TITLE
Trigger a save when scripts are cleaned up

### DIFF
--- a/src/uiwidgets/ScriptsPane.as
+++ b/src/uiwidgets/ScriptsPane.as
@@ -483,6 +483,7 @@ return true; // xxx disable this check for now; it was causing confusion at Scra
 			}
 			nextX += columnWidths[i] + pad;
 		}
+		saveScripts();
 	}
 
 	private function stacksSortedByX():Array {


### PR DESCRIPTION
This fixes a slightly annoying bug where if the only change you have made is cleaning up your scripts, you have to do something else to get a "Save now" button or to trigger an autosave, or you have to find Save now in the menu.
