### PR TITLE
Fixed rounding costume center coordinates in vector mode

### DIFF
--- a/src/svgeditor/BitmapEdit.as
+++ b/src/svgeditor/BitmapEdit.as
@@ -345,7 +345,7 @@ public class BitmapEdit extends ImageEdit {
 	public override function translateContents(x:Number, y:Number):void {
 		var bm:BitmapData = workArea.getBitmap().bitmapData;
 		var newBM:BitmapData = new BitmapData(bm.width, bm.height, true, 0);
-		newBM.copyPixels(bm, bm.rect, new Point(2 * x, 2 * y));
+		newBM.copyPixels(bm, bm.rect, new Point(Math.round(2 * x), Math.round(2 * y)));
 		workArea.getBitmap().bitmapData = newBM;
 	}
 

--- a/src/svgeditor/tools/SetCenterTool.as
+++ b/src/svgeditor/tools/SetCenterTool.as
@@ -96,8 +96,8 @@ package svgeditor.tools
 
 		private function mouseUp(e:MouseEvent):void {
 			var canvas:ImageCanvas = editor.getWorkArea();
-			var ox:int = Math.round(ImageCanvas.canvasWidth / 2 - canvas.getVisibleLayer().mouseX);
-			var oy:int = Math.round(ImageCanvas.canvasHeight / 2 - canvas.getVisibleLayer().mouseY);
+			var ox:Number = ImageCanvas.canvasWidth / 2 - canvas.getVisibleLayer().mouseX;
+			var oy:Number = ImageCanvas.canvasHeight / 2 - canvas.getVisibleLayer().mouseY;
 			editor.translateContents(ox, oy);
 			editor.endCurrentTool();
 		}


### PR DESCRIPTION
This also doubles the resolution of the bitmap costume center tool so that it lines up with the actual pixels of the image.

Fixes #202.
