### PR TITLE
Made list item highlighting more like 1.4

### DIFF
--- a/src/watchers/ListCell.as
+++ b/src/watchers/ListCell.as
@@ -20,19 +20,21 @@
 package watchers {
 import flash.display.Sprite;
 import flash.events.*;
-import flash.geom.ColorTransform;
 import flash.text.*;
 import uiwidgets.ResizeableFrame;
+import util.Color;
 
 public class ListCell extends Sprite {
 
 	private const format:TextFormat = new TextFormat(CSS.font, 11, 0xFFFFFF, true);
+	private static var normalColor:int = Specs.listColor;
+	private static var focusedColor:int = Color.mixRGB(Color.scaleBrightness(Specs.listColor, 2), 0xEEEEEE, 0.6);
 
 	public var tf:TextField;
 	private var frame:ResizeableFrame;
 
 	public function ListCell(s:String, width:int, whenChanged:Function, keyPress:Function) {
-		frame = new ResizeableFrame(0xFFFFFF, Specs.listColor, 6, true);
+		frame = new ResizeableFrame(0xFFFFFF, normalColor, 6, true);
 		addChild(frame);
 		addTextField(whenChanged, keyPress);
 		tf.text = s;
@@ -75,11 +77,9 @@ public class ListCell extends Sprite {
 		tf.setSelection(0, tf.text.length);
 	}
 
-	private static var focused:ColorTransform = new ColorTransform(1, 1, 1, 1, 128, 128, 128, 0);
-	private static var normal:ColorTransform = new ColorTransform(1, 1, 1, 1, 0, 0, 0, 0);
 	private function focusChange(e:FocusEvent):void {
 		var hasFocus:Boolean = (e.type == FocusEvent.FOCUS_IN);
-		frame.transform.colorTransform = (hasFocus ? focused : normal);
+		frame.setColor(hasFocus ? focusedColor : normalColor);
 		tf.textColor = (hasFocus ? 0 : 0xFFFFFF);
 	}
 }}


### PR DESCRIPTION
Before:

![screen shot 2014-05-28 at 16 34 25](https://cloud.githubusercontent.com/assets/1578238/3110639/9ca1040e-e6a7-11e3-8591-a94609cbc242.png)

After:

![screen shot 2014-05-28 at 16 40 38](https://cloud.githubusercontent.com/assets/1578238/3110705/68a9d7f6-e6a8-11e3-9079-4d866cab1860.png)

I'm not entirely sure this is better. Just an option for the design team to discuss. For reference, here's what 1.4 looks like:

![screen shot 2014-05-28 at 16 37 33](https://cloud.githubusercontent.com/assets/1578238/3110669/ec50fde2-e6a7-11e3-9e41-e0d88b2552b8.png)
