### PR TITLE
Make attribute block update when switching sprites

### DIFF
--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -407,7 +407,7 @@ public class BlockMenus implements DragClient {
 				var attr:String = block.args[0].argValue;
 				var validAttrs:Array = obj.isStage ? ['backdrop #', 'background #', 'backdrop name', 'volume'] :
 				['x position', 'y position', 'direction', 'costume #', 'costume name', 'size', 'volume'];
-				if ((validAttrs.indexOf(attr) == -1) && !obj.ownsVar(attr)) block.args[0].setArgValue(obj.isStage ? Translator.map('backdrop #') : Translator.map('x position'));
+				if ((validAttrs.indexOf(attr) == -1) && !obj.ownsVar(attr)) block.args[0].setArgValue(obj.isStage ? 'backdrop #' : 'x position');
 			}
 			Scratch.app.setSaveNeeded();
 		}


### PR DESCRIPTION
When changing the object on the ([x position v] of [Sprite v] block, check if the object has the attribute or variable. If it doesn't, switch to the default attribute. Fixes #70.
