### PR TITLE
Prevent creating a global with the same name as a local

### DIFF
--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -399,7 +399,7 @@ public class BlockMenus implements DragClient {
 		m.addItem('record...', recordSound);
 		showMenu(m);
 	}
-	
+
 	private function recordSound():void {
 		app.setTab('sounds');
 		app.soundsPart.recordSound();
@@ -648,17 +648,14 @@ public class BlockMenus implements DragClient {
 	private function renameVar():void {
 		function doVarRename(dialog:DialogBox):void {
 			var newName:String = dialog.fields['New name'].text.replace(/^\s+|\s+$/g, '');
-			if (newName.length == 0 || app.viewedObj().lookupVar(newName)) return;
-			if (block.op != Specs.GET_VAR) return;
+			if (newName.length == 0 || block.op != Specs.GET_VAR) return;
 			var oldName:String = blockVarOrListName();
 
 			if (oldName.charAt(0) == '\u2601') { // Retain the cloud symbol
 				newName = '\u2601 ' + newName;
 			}
 
-			app.runtime.renameVariable(oldName, newName, block);
-			setBlockVarOrListName(newName);
-			app.updatePalette();
+			app.runtime.renameVariable(oldName, newName);
 		}
 		var d:DialogBox = new DialogBox(doVarRename);
 		d.addTitle(Translator.map('Rename') + ' ' + blockVarOrListName());

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -174,7 +174,7 @@ public class PaletteBuilder {
 
 	protected function createVar(name:String, varSettings:VariableSettings):* {
 		var obj:ScratchObj = (varSettings.isLocal) ? app.viewedObj() : app.stageObj();
-		if (obj.anyChildOwnsVar(name)) {
+		if (obj.hasVarName(name)) {
 			DialogBox.notify("Cannot Add", "That variable name is already in use.");
 			return;
 		}

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -174,6 +174,10 @@ public class PaletteBuilder {
 
 	protected function createVar(name:String, varSettings:VariableSettings):* {
 		var obj:ScratchObj = (varSettings.isLocal) ? app.viewedObj() : app.stageObj();
+		if (obj.anyChildOwnsVar(name)) {
+			DialogBox.notify("Cannot Add", "That variable name is already in use.");
+			return;
+		}
 		var variable:* = (varSettings.isList ? obj.lookupOrCreateList(name) : obj.lookupOrCreateVar(name));
 
 		app.runtime.showVarOrListFor(name, varSettings.isList, obj);

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -175,7 +175,7 @@ public class PaletteBuilder {
 	protected function createVar(name:String, varSettings:VariableSettings):* {
 		var obj:ScratchObj = (varSettings.isLocal) ? app.viewedObj() : app.stageObj();
 		if (obj.hasVarName(name)) {
-			DialogBox.notify("Cannot Add", "That variable name is already in use.");
+			DialogBox.notify("Cannot Add", "That name is already in use.");
 			return;
 		}
 		var variable:* = (varSettings.isList ? obj.lookupOrCreateList(name) : obj.lookupOrCreateVar(name));

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -174,7 +174,7 @@ public class PaletteBuilder {
 
 	protected function createVar(name:String, varSettings:VariableSettings):* {
 		var obj:ScratchObj = (varSettings.isLocal) ? app.viewedObj() : app.stageObj();
-		if (obj.hasVarName(name)) {
+		if (obj.hasName(name)) {
 			DialogBox.notify("Cannot Add", "That name is already in use.");
 			return;
 		}

--- a/src/scratch/ScratchObj.as
+++ b/src/scratch/ScratchObj.as
@@ -448,7 +448,7 @@ public class ScratchObj extends Sprite {
 		return false;
 	}
 
-	public function hasVarName(varName:String):Boolean {
+	public function hasName(varName:String):Boolean {
 		var p:ScratchObj = parent as ScratchObj;
 		return ownsVar(varName) || ownsList(varName) || p && (p.ownsVar(varName) || p.ownsList(varName));
 	}

--- a/src/scratch/ScratchObj.as
+++ b/src/scratch/ScratchObj.as
@@ -448,8 +448,8 @@ public class ScratchObj extends Sprite {
 		return false;
 	}
 
-	public function anyChildOwnsVar(varName:String):Boolean {
-		return ownsVar(varName);
+	public function hasVarName(varName:String):Boolean {
+		return ownsVar(varName) || ScratchObj(parent).ownsVar(varName);
 	}
 
 	public function lookupOrCreateVar(varName:String):Variable {

--- a/src/scratch/ScratchObj.as
+++ b/src/scratch/ScratchObj.as
@@ -449,7 +449,8 @@ public class ScratchObj extends Sprite {
 	}
 
 	public function hasVarName(varName:String):Boolean {
-		return ownsVar(varName) || ScratchObj(parent).ownsVar(varName);
+		var p:ScratchObj = parent as ScratchObj;
+		return ownsVar(varName) || ownsList(varName) || p && (p.ownsVar(varName) || p.ownsList(varName));
 	}
 
 	public function lookupOrCreateVar(varName:String):Variable {

--- a/src/scratch/ScratchObj.as
+++ b/src/scratch/ScratchObj.as
@@ -25,23 +25,23 @@
 
 package scratch {
 	import blocks.*;
-	
+
 	import filters.FilterPack;
-	
+
 	import flash.display.*;
 	import flash.events.MouseEvent;
 import flash.geom.ColorTransform;
 import flash.utils.*;
-	
+
 	import interpreter.*;
-	
+
 	import scratch.ScratchComment;
 import scratch.ScratchSprite;
 
 import translation.Translator;
-	
+
 	import util.*;
-	
+
 	import watchers.*;
 
 public class ScratchObj extends Sprite {
@@ -446,6 +446,10 @@ public class ScratchObj extends Sprite {
 			if (v.name == varName) return true;
 		}
 		return false;
+	}
+
+	public function anyChildOwnsVar(varName:String):Boolean {
+		return ownsVar(varName);
 	}
 
 	public function lookupOrCreateVar(varName:String):Variable {

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -590,19 +590,24 @@ public class ScratchRuntime {
 		return result;
 	}
 
-	public function renameVariable(oldName:String, newName:String, block:Block):void {
+	public function renameVariable(oldName:String, newName:String):void {
+		if (oldName == newName) return;
 		var owner:ScratchObj = app.viewedObj();
-		var v:Variable = owner.lookupVar(oldName);
+		if (!owner.ownsVar(oldName)) owner = app.stagePane;
+		if (owner.hasName(newName)) {
+			DialogBox.notify("Cannot Rename", "That name is already in use.");
+			return;
+		}
 
+		var v:Variable = owner.lookupVar(oldName);
 		if (v != null) {
-			if (!owner.ownsVar(v.name)) owner = app.stagePane;
 			v.name = newName;
 			if (v.watcher) v.watcher.changeVarName(newName);
 		} else {
 			owner.lookupOrCreateVar(newName);
 		}
 		updateVarRefs(oldName, newName, owner);
-		clearAllCaches();
+		app.updatePalette();
 	}
 
 	public function updateVariable(v:Variable):void {}

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -136,9 +136,9 @@ public class ScratchStage extends ScratchObj {
 	override public function hasVarName(varName:String):Boolean {
 		// Return true if this object owns a variable of the given name.
 		for each (var s:ScratchSprite in sprites()) {
-			if (s.ownsVar(varName)) return true;
+			if (s.ownsVar(varName) || s.ownsList(varName)) return true;
 		}
-		return ownsVar(varName);
+		return ownsVar(varName) || ownsList(varName);
 	}
 
 	private function initMedia():void {

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -133,13 +133,12 @@ public class ScratchStage extends ScratchObj {
 		return withoutTrailingDigits(baseName) + i;
 	}
 
-	override public function anyChildOwnsVar(varName:String):Boolean {
+	override public function hasVarName(varName:String):Boolean {
 		// Return true if this object owns a variable of the given name.
-		if (ownsVar(varName)) return true;
 		for each (var s:ScratchSprite in sprites()) {
 			if (s.ownsVar(varName)) return true;
 		}
-		return false;
+		return ownsVar(varName);
 	}
 
 	private function initMedia():void {

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -133,6 +133,15 @@ public class ScratchStage extends ScratchObj {
 		return withoutTrailingDigits(baseName) + i;
 	}
 
+	override public function anyChildOwnsVar(varName:String):Boolean {
+		// Return true if this object owns a variable of the given name.
+		if (ownsVar(varName)) return true;
+		for each (var s:ScratchSprite in sprites()) {
+			if (s.ownsVar(varName)) return true;
+		}
+		return false;
+	}
+
 	private function initMedia():void {
 		costumes.push(ScratchCostume.emptyBitmapCostume(Translator.map('backdrop1'), true));
 		sounds.push(new ScratchSound(Translator.map('pop'), new Pop()));

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -133,7 +133,7 @@ public class ScratchStage extends ScratchObj {
 		return withoutTrailingDigits(baseName) + i;
 	}
 
-	override public function hasVarName(varName:String):Boolean {
+	override public function hasName(varName:String):Boolean {
 		// Return true if this object owns a variable of the given name.
 		for each (var s:ScratchSprite in sprites()) {
 			if (s.ownsVar(varName) || s.ownsList(varName)) return true;


### PR DESCRIPTION
This also adds a dialog box explaining why the variable could not be created and prevents creating a list with the same name as a variable.

Fixes #119.
Fixes #349.
Fixes #374.
