### PR TITLE
Change library UI so sprites with empty names and costumes are still visible

### DIFF
--- a/src/ui/SpriteThumbnail.as
+++ b/src/ui/SpriteThumbnail.as
@@ -45,6 +45,7 @@ public class SpriteThumbnail extends Sprite {
 	private var thumbnail:Bitmap;
 	private var label:TextField;
 	private var sceneInfo:TextField;
+	private var normalFrame:Shape;
 	private var selectedFrame:Shape;
 	private var highlightFrame:Shape;
 	private var infoSprite:Sprite;
@@ -58,6 +59,7 @@ public class SpriteThumbnail extends Sprite {
 		this.targetObj = targetObj;
 		this.app = app;
 
+		if (!targetObj.isStage) addNormalFrame();
 		addSelectedFrame();
 		addHighlightFrame();
 
@@ -90,6 +92,15 @@ public class SpriteThumbnail extends Sprite {
 		detailsButton.isMomentary = true;
 		detailsButton.visible = false;
 		addChild(detailsButton);
+	}
+
+	private function addNormalFrame():void {
+		normalFrame = new Shape();
+		var g:Graphics = normalFrame.graphics;
+		g.lineStyle(1, CSS.borderColor, 1, true);
+		g.drawRect(-4, -4, frameW + 8, frameH + 8);
+		g.endFill();
+		addChild(normalFrame);
 	}
 
 	private function addSelectedFrame():void {

--- a/src/ui/parts/LibraryPart.as
+++ b/src/ui/parts/LibraryPart.as
@@ -203,10 +203,10 @@ public class LibraryPart extends UIPart {
 			tn.x = nextX;
 			tn.y = nextY;
 			spritesPane.addChild(tn);
-			nextX += tn.width;
-			if ((nextX + tn.width) > rightEdge) { // start new line
+			nextX += tn.width - 1;
+			if ((nextX + tn.width - 1) > rightEdge) { // start new line
 				nextX = inset;
-				nextY += tn.height;
+				nextY += tn.height - 1;
 			}
 		}
 		spritesPane.updateSize();


### PR DESCRIPTION
Looks like this:

![screen shot 2014-06-24 at 14 38 23](https://cloud.githubusercontent.com/assets/1578238/3375873/05ce9914-fbcf-11e3-873f-17bafc342add.png)

Fixes #106.
