### PR TITLE
Fix corner rounding

### DIFF
--- a/src/scratch/TalkBubble.as
+++ b/src/scratch/TalkBubble.as
@@ -93,7 +93,7 @@ public class TalkBubble extends Sprite {
 		var g:Graphics = shape.graphics;
 		g.clear();
 		g.beginFill(0xFFFFFF);
-		g.lineStyle(lineWidth, outlineColor);
+		g.lineStyle(lineWidth, outlineColor, 1, true);
 		if (type == 'think') drawThink(w, h);
 		else drawTalk(w, h);
 	}

--- a/src/uiwidgets/ResizeableFrame.as
+++ b/src/uiwidgets/ResizeableFrame.as
@@ -95,7 +95,7 @@ public class ResizeableFrame extends Sprite implements DragClient {
 		// outline
 		g = outline.graphics;
 		g.clear();
-		g.lineStyle(borderWidth, borderColor);
+		g.lineStyle(borderWidth, borderColor, 1, true);
 		g.drawRoundRect(0, 0, w, h, cornerRadius, cornerRadius);
 
 		if (resizer) {


### PR DESCRIPTION
This improves the quality of rounded corners in list and variable watchers:

Before/after:
![screen shot 2014-07-08 at 14 08 52](https://cloud.githubusercontent.com/assets/1578238/3514313/15615900-06cb-11e4-8852-73cc6e7e984f.png) ![screen shot 2014-07-08 at 14 08 58](https://cloud.githubusercontent.com/assets/1578238/3514315/1829cfe6-06cb-11e4-97d5-354a9b3b2767.png)

as well as talk bubbles:

Before/after:
![screen shot 2014-07-08 at 17 25 04](https://cloud.githubusercontent.com/assets/1578238/3516845/5f1c9e9a-06e6-11e4-8872-4cdd2da89065.png) ![screen shot 2014-07-08 at 17 24 16](https://cloud.githubusercontent.com/assets/1578238/3516841/58003400-06e6-11e4-8423-95b19564aae6.png)