### PR TITLE
Allow only one HTTP poll at a time per extension

### DIFF
--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -512,8 +512,9 @@ public class ExtensionManager {
 			processPollResponse(ext, loader.data);
 		}
 		function errorHandler(e:Event):void {
+			// ignore errors
 			delete pollInProgress[ext];
-		} // ignore errors
+		}
 		var url:String = 'http://' + ext.host + ':' + ext.port + '/poll';
 		var loader:URLLoader = new URLLoader();
 		loader.addEventListener(Event.COMPLETE, completeHandler);


### PR DESCRIPTION
Without this change, long-running poll requests (such as those resulting in a timeout) can cause arbitrarily long request queues, eventually leading to spontaneous termination of the application.
