### PR TITLE
Stop bolding numeric arguments

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -228,7 +228,7 @@ public class Block extends Sprite {
 		var font:String = Resources.chooseFont([
 			'Lucida Grande', 'Verdana', 'Arial', 'DejaVu Sans']);
 		blockLabelFormat = new TextFormat(font, labelSize, 0xFFFFFF, boldFlag);
-		argTextFormat = new TextFormat(font, argSize, 0x505050, boldFlag);
+		argTextFormat = new TextFormat(font, argSize, 0x505050, false);
 		Block.vOffset = vOffset;
 	}
 

--- a/src/blocks/BlockArg.as
+++ b/src/blocks/BlockArg.as
@@ -202,7 +202,6 @@ public class BlockArg extends Sprite {
 		tf.x = offsets[0];
 		tf.y = offsets[1];
 		tf.autoSize = TextFieldAutoSize.LEFT;
-		Block.argTextFormat.bold = isNumber;
 		tf.defaultTextFormat = Block.argTextFormat;
 		tf.selectable = false;
 		tf.addEventListener(Event.CHANGE, textChanged);


### PR DESCRIPTION
This makes numeric arguments look more like arguments.

Before/after:
![screen shot 2014-07-09 at 14 32 00](https://cloud.githubusercontent.com/assets/1578238/3529215/57a399fa-0797-11e4-9ee8-d8288b08dec4.png) ![screen shot 2014-07-08 at 14 54 29](https://cloud.githubusercontent.com/assets/1578238/3515010/511c3716-06d1-11e4-87aa-363cac50d4eb.png)

![comparison](https://cloud.githubusercontent.com/assets/1578238/3529267/f3090880-0797-11e4-85cd-7a757edfddbd.png)
