### PR TITLE
Prevent using special names (e.g., _mouse_) as sprite names

### DIFF
--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -121,7 +121,7 @@ public class ScratchStage extends ScratchObj {
 	}
 
 	public function unusedSpriteName(baseName:String):String {
-		var existingNames:Array = [];
+		var existingNames:Array = ['_mouse_', '_stage_', '_edge_', '_myself_'];
 		for each (var s:ScratchSprite in sprites()) {
 			existingNames.push(s.objName.toLowerCase());
 		}


### PR DESCRIPTION
Fixes #359.
