### PR TITLE
Fix unintended sprite dragging while drawing

### DIFF
--- a/src/svgeditor/tools/PathEndPoint.as
+++ b/src/svgeditor/tools/PathEndPoint.as
@@ -63,6 +63,7 @@ package svgeditor.tools
 
 		private function proxyEvent(e:MouseEvent):void {
 			editor.getCanvasLayer().dispatchEvent(e);
+			e.stopImmediatePropagation();
 		}
 
 		private function showOrb(e:MouseEvent):void {


### PR DESCRIPTION
I'm not sure if there is a bug created for this but my daughter showed me this bug over the weekend. You end up picking up another sprite while editing a costume (moving the end point of a path in the path edit tool).
