### PR TITLE
Fix args appearing when variable names contain %n, etc.

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -190,6 +190,8 @@ public class Block extends Sprite {
 			labelsAndArgs.push(label);
 			var b:Block;
 			labelsAndArgs.push(b = declarationBlock());
+		} else if (op == Specs.GET_VAR || op == Specs.GET_LIST) {
+			labelsAndArgs.push(makeLabel(spec));
 		} else {
 			const loopBlocks:Array = ['doForever', 'doForeverIf', 'doRepeat', 'doUntil'];
 			base.hasLoopArrow = (loopBlocks.indexOf(op) >= 0);


### PR DESCRIPTION
Fixes #340.
