### PR TITLE
Sound Loudness block

### DIFF
--- a/src/Specs.as
+++ b/src/Specs.as
@@ -179,7 +179,7 @@ public class Specs {
 		["play sound %m.sound",					" ", 3, "playSound:",						"pop"],
 		["play sound %m.sound until done",		" ", 3, "doPlaySoundAndWait",				"pop"],
 		["stop all sounds",						" ", 3, "stopAllSounds"],
-		["sound data",                          "r", 3, "getSoundData"],
+		["sound loudness",                          "r", 3, "getSoundData"],
 		["-"],
 		["play drum %d.drum for %n beats",		" ", 3, "playDrum",							1, 0.25],
 		["rest for %n beats",					" ", 3, "rest:elapsed:from:",				0.25],

--- a/src/primitives/SoundPrims.as
+++ b/src/primitives/SoundPrims.as
@@ -93,6 +93,7 @@ public class SoundPrims {
 		for(var i:int = 0; i<512; i++)
 		{
 			var value:Number = bytes.readFloat();
+			value = Math.round(value * 70.7213) // this will convert the value given which is from 0 - 1.414 to a value of 0-100 and then rounds it.
 			return value;
 		}
 	return value;


### PR DESCRIPTION
--- I was unaware that the Scratch Team had to approve additions.  Sorry for any trouble.  I have created a discussion page and hope that they approve it. (http://scratch.mit.edu/discuss/topic/46150/) Sorry for any troubles my new-ness has caused.

This block returns a number between 0 and 100.  It accesses the SoundMixer.computeSpectrum() method to get the raw sound data of all currently playing sounds.  It is similar to the loudness block, but does not get the information from the microphone, it gets it from any currently playing sounds in the project. 

![capture](https://cloud.githubusercontent.com/assets/7967463/3651681/c887791e-112b-11e4-9f21-5db9018d36c1.PNG)

It can be used to create enemies in a game based on the frequency of the music playing, to create audio visualizers, or to have anything react to the sound.

A project where this could be implemented is here: http://scratch.mit.edu/projects/23370689/.  This project was recently featured, but many scratchers commented complaining that they couldn't use the project because they didn't have a microphone.

If you would like to test it online, here is the .swf file: https://dl.dropboxusercontent.com/u/76236043/scratch/Scratch.swf

Here is a song that works great for testing!: https://www.dropbox.com/s/fmdjapbkr3ak368/Transcendence.wav

And Thepuzzlegame has created a demo file: 
https://www.dropbox.com/s/tdcrshbl58cqlz3/sound%20levels%20test.sb2
