### PR TITLE
Use setSVGData() to properly clear a costume that failed to load

### DIFF
--- a/src/util/ProjectIO.as
+++ b/src/util/ProjectIO.as
@@ -409,7 +409,7 @@ public class ProjectIO {
 			for each (var c:ScratchCostume in obj.costumes) {
 				data = assetDict[c.baseLayerMD5];
 				if (data) c.baseLayerData = data;
-				else c.baseLayerData = ScratchCostume.emptySVG(); // missing asset data; use empty costume
+				else c.setSVGData(ScratchCostume.emptySVG(), true); // missing asset data; use empty costume
 				if (c.textLayerMD5) c.textLayerData = assetDict[c.textLayerMD5];
 			}
 			for each (var snd:ScratchSound in obj.sounds) {


### PR DESCRIPTION
This should fix https://github.com/LLK/scratch-flash/issues/403 but we really need to still look into why assets sometimes fail to load.
