### PR TITLE
Fix renaming sounds in nested blocks

### DIFF
--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -827,8 +827,8 @@ public class ScratchRuntime {
     public function allUsesOfSoundDo(soundName:String, f:Function):void {
         for each (var stack:Block in app.viewedObj().scripts) {
             stack.allBlocksDo(function (b:Block):void {
-                for each (var a:BlockArg in b.args) {
-                    if (a.menuName == 'sound' && a.argValue == soundName) f(a);
+                for each (var a:* in b.args) {
+                    if (a is BlockArg && a.menuName == 'sound' && a.argValue == soundName) f(a);
                 }
             });
         }


### PR DESCRIPTION
Missed this one in ba11fd3ba502eda0eda5d9533a382e924d5ea909.
