### PR TITLE
Fix for parameter focusing

### DIFF
--- a/src/ui/ProcedureSpecEditor.as
+++ b/src/ui/ProcedureSpecEditor.as
@@ -292,10 +292,7 @@ public class ProcedureSpecEditor extends Sprite {
 		addChild(o);
 		if (stage) {
 			if (o is TextField) stage.focus = TextField(o);
-			if (o is BlockArg) {
-				var arg:BlockArg = o as BlockArg;
-				arg.startEditing();
-			}
+			if (o is BlockArg) BlockArg(o).startEditing();	
 		}
 		fixLayout();
 		if (parent is DialogBox) DialogBox(parent).fixLayout();
@@ -424,10 +421,7 @@ public class ProcedureSpecEditor extends Sprite {
 	private function setFocus(o:DisplayObject):void {
 		if (!stage) return;
 		if (o is TextField) stage.focus = TextField(o);
-		if (o is BlockArg) {
-			var arg:BlockArg = o as BlockArg;
-			arg.startEditing();
-		}
+		if (o is BlockArg) BlockArg(o).startEditing();			
 	}
 
 	private function focusChange(evt:FocusEvent):void {

--- a/src/ui/ProcedureSpecEditor.as
+++ b/src/ui/ProcedureSpecEditor.as
@@ -292,7 +292,10 @@ public class ProcedureSpecEditor extends Sprite {
 		addChild(o);
 		if (stage) {
 			if (o is TextField) stage.focus = TextField(o);
-			if (o is BlockArg) stage.focus = BlockArg(o).field;
+			if (o is BlockArg) {
+				var arg:BlockArg = o as BlockArg;
+				arg.startEditing();
+			}
 		}
 		fixLayout();
 		if (parent is DialogBox) DialogBox(parent).fixLayout();
@@ -421,7 +424,10 @@ public class ProcedureSpecEditor extends Sprite {
 	private function setFocus(o:DisplayObject):void {
 		if (!stage) return;
 		if (o is TextField) stage.focus = TextField(o);
-		if (o is BlockArg) stage.focus = BlockArg(o).field;
+		if (o is BlockArg) {
+			var arg:BlockArg = o as BlockArg;
+			arg.startEditing();
+		}
 	}
 
 	private function focusChange(evt:FocusEvent):void {


### PR DESCRIPTION
Fixes #414

Try it here: https://dl.dropboxusercontent.com/u/76236043/scratch/parameterFocus.swf

I also changed the code so when you re-open a procedure to edit it, the first parameter receives keyboard focus, not the first text object as the code was previously doing.

(My first bugfix, yay!)
