### PR TITLE
Revert "Use setSVGData() to properly clear a costume that failed to load...

### DIFF
--- a/src/util/ProjectIO.as
+++ b/src/util/ProjectIO.as
@@ -409,7 +409,7 @@ public class ProjectIO {
 			for each (var c:ScratchCostume in obj.costumes) {
 				data = assetDict[c.baseLayerMD5];
 				if (data) c.baseLayerData = data;
-				else c.setSVGData(ScratchCostume.emptySVG(), true); // missing asset data; use empty costume
+				else c.baseLayerData = ScratchCostume.emptySVG(); // missing asset data; use empty costume
 				if (c.textLayerMD5) c.textLayerData = assetDict[c.textLayerMD5];
 			}
 			for each (var snd:ScratchSound in obj.sounds) {


### PR DESCRIPTION
> Since the asset failed to load there is a good chance that it was never saved properly. This would account for the MD5 (generated by the editor) being in the project data but not having content for it on the server.

Except we _do_ have content for it on the server. The bug is about _losing_ assets, not failing to save them. https://github.com/LLK/scratch-flash/issues/403#issuecomment-50528867
