### PR TITLE
Check for internal extension before fixing URL

### DIFF
--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -95,7 +95,7 @@ public class ExtensionManager {
 			ext.showBlocks = flag;
 			if(app.jsEnabled && ext.javascriptURL) {
 				if(flag) {
-					var javascriptURL:String = Scratch.app.fixExtensionURL(ext.javascriptURL);
+					var javascriptURL:String = ext.isInternal ? Scratch.app.fixExtensionURL(ext.javascriptURL) : ext.javascriptURL;
 					app.externalCall('ScratchExtensions.loadExternalJS', null, javascriptURL);
 					ext.showBlocks = false; // Wait for it to load
 				}


### PR DESCRIPTION
Only internal extensions need their URLs fixed. We should probably find
a better way to do this, but it's tricky if we want the offline editor
to be able to load internal extensions without an Internet connection.

In practice this change only affects the offline editor, since fixExtensionURL is a no-op in other builds.
