### PR TITLE
Add exporting project summaries

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -734,6 +734,10 @@ public class Scratch extends Sprite {
 			m.addItem('Revert', revertToOriginalProject);
 		}
 
+		if (b.lastEvent.shiftKey) {
+			m.addLine();
+			m.addItem('Save Project Summary', saveSummary);
+		}
 		if (b.lastEvent.shiftKey && jsEnabled) {
 			m.addLine();
 			m.addItem('Import experimental extension', function():void {
@@ -847,6 +851,12 @@ public class Scratch extends Sprite {
 			result += (illegal.indexOf(ch) > -1) ? '-' : ch;
 		}
 		return result;
+	}
+
+	public function saveSummary():void {
+		var name:String = (projectName() || "project") + ".txt";
+		var file:FileReference = new FileReference();
+		file.save(stagePane.getSummary(), fixFileName(name));
 	}
 
 	public function toggleSmallStage():void {

--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -911,4 +911,45 @@ public class Block extends Sprite {
 		}
 	}
 
+	public function getSummary():String {
+		var s:String = type == "r" ? "(" : type == "b" ? "<" : "";
+		var space:Boolean = false;
+		for each (var x:DisplayObject in labelsAndArgs) {
+			if (space) {
+				s += " ";
+			}
+			space = true;
+			var ba:BlockArg, b:Block, tf:TextField;
+			if ((ba = x as BlockArg)) {
+				s += ba.isNumber ? "(" : "[";
+				s += ba.argValue;
+				if (!ba.isEditable) s += " v";
+				s += ba.isNumber ? ")" : "]";
+			} else if ((b = x as Block)) {
+				s += b.getSummary();
+			} else if ((tf = x as TextField)) {
+				s += TextField(x).text;
+			} else {
+				s += "@";
+			}
+		}
+		if (base.canHaveSubstack1()) {
+			s += "\n" + (subStack1 ? indent(subStack1.getSummary()) : "");
+			if (base.canHaveSubstack2()) {
+				s += "\n" + elseLabel.text;
+				s += "\n" + (subStack2 ? indent(subStack2.getSummary()) : "");
+			}
+			s += "\n" + Translator.map("end");
+		}
+		if (nextBlock) {
+			s += "\n" + nextBlock.getSummary();
+		}
+		s += type == "r" ? ")" : type == "b" ? ">" : "";
+		return s;
+	}
+
+	protected static function indent(s:String):String {
+		return s.replace(/^/gm, "    ");
+	}
+
 }}

--- a/src/scratch/ScratchObj.as
+++ b/src/scratch/ScratchObj.as
@@ -657,4 +657,53 @@ public class ScratchObj extends Sprite {
 		}
 	}
 
+	public function getSummary():String {
+		var s:Array = [];
+		s.push(h1(objName));
+		if (variables.length) {
+			s.push(h2(Translator.map("Variables")));
+			for each (var v:Variable in variables) {
+				s.push("- " + v.name + " = " + v.value);
+			}
+			s.push("");
+		}
+		if (lists.length) {
+			s.push(h2(Translator.map("Lists")));
+			for each (var list:ListWatcher in lists) {
+				s.push("- " + list.listName + (list.contents.length ? ":" : ""));
+				for each (var item:* in list.contents) {
+					s.push("    - " + item);
+				}
+			}
+			s.push("");
+		}
+		s.push(h2(Translator.map(isStage ? "Backdrops" : "Costumes")));
+		for each (var costume:ScratchCostume in costumes) {
+			s.push("- " + costume.costumeName);
+		}
+		s.push("");
+		if (sounds.length) {
+			s.push(h2(Translator.map("Sounds")));
+			for each (var sound:ScratchSound in sounds) {
+				s.push("- " + sound.soundName);
+			}
+			s.push("");
+		}
+		if (scripts.length) {
+			s.push(h2(Translator.map("Scripts")));
+			for each (var script:Block in scripts) {
+				s.push(script.getSummary());
+				s.push("")
+			}
+		}
+		return s.join("\n");
+	}
+
+	protected static function h1(s:String, ch:String = "="):String {
+		return s + "\n" + new Array(s.length + 1).join(ch) + "\n";
+	}
+	protected static function h2(s:String):String {
+		return h1(s, "-");
+	}
+
 }}

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -813,4 +813,12 @@ public class ScratchStage extends ScratchObj {
 		}
 	}
 
+	public override function getSummary():String {
+		var summary:String = super.getSummary();
+		for each (var s:ScratchSprite in sprites()) {
+			summary += "\n\n" + s.getSummary();
+		}
+		return summary;
+	}
+
 }}


### PR DESCRIPTION
This allows users to export a plain-text summary of a project which includes the variables, lists, scripts, costume names, and sound names of every sprite. It looks like this: https://gist.github.com/nathan/98a73b2d0824f1bbf81b#file-spirals-txt (the scripts are in [scratchblocks2](http://blob8108.github.io/scratchblocks2/) format)

Fixes #15.
