### PR TITLE
Stub getBackpack() in MediaInfo, move some checks

### DIFF
--- a/src/ui/media/MediaInfo.as
+++ b/src/ui/media/MediaInfo.as
@@ -66,8 +66,6 @@ public class MediaInfo extends Sprite {
 	private var info:TextField;
 	private var deleteButton:IconButton;
 
-	protected var loaders:Array = []; // list of URLLoaders for stopLoading()
-
 	public function MediaInfo(obj:*, owningObj:ScratchObj = null) {
 		owner = owningObj;
 		mycostume = obj as ScratchCostume;


### PR DESCRIPTION
This change involves both the scratch-flash and scratch-flash-online repositories.
See also LLK/scratch-flash-online#36
This allows more code to be shared between the online, offline, and open-source editors. This also fixes the 'duplicate' menu option being absent on costumes in the offline and open-source editors.
