### PR TITLE
Calc MD5 in setters for sound and costume data

### DIFF
--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -59,7 +59,7 @@ public class ScratchCostume {
 	public var baseLayerBitmap:BitmapData;
 	public var baseLayerID:int = -1;
 	public var baseLayerMD5:String;
-	public var baseLayerData:ByteArray;
+	private var __baseLayerData:ByteArray;
 
 	public static const WasEdited:int = -10; // special baseLayerID used to indicate costumes that have been edited
 
@@ -74,7 +74,7 @@ public class ScratchCostume {
 	public var textLayerBitmap:BitmapData;
 	public var textLayerID:int = -1;
 	public var textLayerMD5:String;
-	public var textLayerData:ByteArray;
+	private var __textLayerData:ByteArray;
 
 	public var text:String;
 	public var textRect:Rectangle;
@@ -101,6 +101,24 @@ public class ScratchCostume {
 			setSVGData(data, (centerX == 99999));
 			prepareToSave();
 		}
+	}
+
+	public function get baseLayerData():ByteArray {
+		return __baseLayerData;
+	}
+
+	public function set baseLayerData(data:ByteArray):void {
+		__baseLayerData = data;
+		baseLayerMD5 = data ? by.blooddy.crypto.MD5.hashBytes(data) + fileExtension(data) : null;
+	}
+
+	public function get textLayerData():ByteArray {
+		return __textLayerData;
+	}
+
+	public function set textLayerData(data:ByteArray):void {
+		__textLayerData = data;
+		textLayerMD5 = data ? by.blooddy.crypto.MD5.hashBytes(data) + fileExtension(data) : null;
 	}
 
 	public static function scaleForScratch(bm:BitmapData):BitmapData {

--- a/src/scratch/ScratchSound.as
+++ b/src/scratch/ScratchSound.as
@@ -41,7 +41,7 @@ public class ScratchSound {
 	public var soundName:String = '';
 	public var soundID:int;
 	public var md5:String;
-	public var soundData:ByteArray = new ByteArray();
+	private var __soundData:ByteArray = new ByteArray();
 	public var format:String = '';
 	public var rate:int = 44100;
 	public var sampleCount:int;
@@ -69,6 +69,15 @@ public class ScratchSound {
 				setSamples(new Vector.<int>(0), 22050);
 			}
 		}
+	}
+
+	public function get soundData():ByteArray {
+		return __soundData;
+	}
+
+	public function set soundData(data:ByteArray):void {
+		__soundData = data;
+		md5 = data ? by.blooddy.crypto.MD5.hashBytes(soundData) + '.wav' : null;
 	}
 
 	private function reduceSizeIfNeeded(channels:int):void {


### PR DESCRIPTION
**NOTE**: This pull request is against the v424 branch.

This change calculates the new MD5 for costume or sound data in a new setter for that data. This should eliminate the possibility of the data and MD5 getting out of sync.
