### PR TITLE
Ensure all loadBytes calls handle IOErrorEvent

### DIFF
--- a/src/util/ProjectIO.as
+++ b/src/util/ProjectIO.as
@@ -30,9 +30,8 @@ package util {
 import flash.display.*;
 import flash.events.*;
 import flash.net.URLLoader;
-import flash.net.URLLoaderDataFormat;
-import flash.net.URLRequest;
 import flash.utils.*;
+
 import scratch.*;
 
 import sound.WAVFile;
@@ -325,8 +324,12 @@ public class ProjectIO {
 			} else {
 				var loader:Loader = new Loader();
 				loader.contentLoaderInfo.addEventListener(Event.COMPLETE, imageLoaded);
+				loader.contentLoaderInfo.addEventListener(IOErrorEvent.IO_ERROR, imageError);
 				loader.loadBytes(data);
 			}
+		}
+		function imageError(event:IOErrorEvent):void {
+			app.log('ProjectIO failed to load: ' + id);
 		}
 		function imageLoaded(e:Event):void {
 			c = new ScratchCostume(costumeName, e.target.content.bitmapData);

--- a/src/util/Server.as
+++ b/src/util/Server.as
@@ -95,8 +95,12 @@ public class Server implements IServer {
 			if (data) {
 				var loader:Loader = new Loader();
 				loader.contentLoaderInfo.addEventListener(Event.COMPLETE, imageLoaded);
+				loader.contentLoaderInfo.addEventListener(IOErrorEvent.IO_ERROR, imageError);
 				try { loader.loadBytes(data) } catch (e:*) {}
 			}
+		}
+		function imageError(e:IOErrorEvent):void {
+			Scratch.app.log('Server failed to load thumbnail: ' + md5);
 		}
 		function imageLoaded(e:Event):void {
 			whenDone(makeThumbnail(e.target.content.bitmapData));


### PR DESCRIPTION
Added IO error handlers to all Loader.loadBytes() calls, and put distinct log messages in each one.
