### PR TITLE
Fix Bug #460: recover user selected language at start up

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -138,6 +138,9 @@ public class Scratch extends Sprite {
 
 		playerBG = new Shape(); // create, but don't add
 		addParts();
+		
+		server.getSelectedLang(Translator.setLanguageValue);
+		
 
 		stage.addEventListener(MouseEvent.MOUSE_DOWN, gh.mouseDown);
 		stage.addEventListener(MouseEvent.MOUSE_MOVE, gh.mouseMove);

--- a/src/translation/Translator.as
+++ b/src/translation/Translator.as
@@ -57,7 +57,7 @@ public class Translator {
 		Scratch.app.server.getLanguageList(saveLanguageList);
 	}
 
-	public static function setLanguage(lang:String):void {
+	public static function setLanguageValue(lang:String):void {
 		function gotPOFile(data:ByteArray):void {
 			if (data) {
 				dictionary = parsePOData(data);
@@ -66,14 +66,19 @@ public class Translator {
 			}
 			Scratch.app.translationChanged();
 		}
-		if ('import translation file' == lang) { importTranslationFromFile(); return; }
-		if ('set font size' == lang) { fontSizeMenu(); return; }
-
+		
 		dictionary = {}; // default to English (empty dictionary) if there's no .po file
 		setFontsFor('en');
 		if ('en' == lang) Scratch.app.translationChanged(); // there is no .po file English
 		else Scratch.app.server.getPOFile(lang, gotPOFile);
 
+	}
+	
+	public static function setLanguage(lang:String):void {
+		if ('import translation file' == lang) { importTranslationFromFile(); return; }
+		if ('set font size' == lang) { fontSizeMenu(); return; }
+		
+		setLanguageValue(lang);
 		Scratch.app.server.setSelectedLang(lang);
 	}
 


### PR DESCRIPTION
Little refactor of Translator.setLanguage(). n bootstrap phase call
getLanguage() from server and set the value in the interface.
