### PR TITLE
Don't render things behind a sprite with subpixel coordinates

### DIFF
--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -522,7 +522,7 @@ public class ScratchStage extends ScratchObj {
 
 		var m:Matrix = new Matrix();
 		m.translate(-Math.floor(r.x), -Math.floor(r.y));
-		bm.draw(cachedBM, m, null);
+		bm.draw(cachedBM, m);
 
 		for (var i:int = 0; i < this.numChildren; i++) {
 			var o:ScratchSprite = this.getChildAt(i) as ScratchSprite;


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-flash/issues/63
