### PR TITLE
reverted stack restarting for whenKeyPressed hats

### DIFF
--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -195,7 +195,8 @@ public class ScratchRuntime {
 		if (keyName == null) return;
 		var startMatchingKeyHats:Function = function (stack:Block, target:ScratchObj):void {
 			if ((stack.op == 'whenKeyPressed') && (stack.args[0].argValue == keyName)) {
-				interp.restartThread(stack, target);
+				// only start the stack if it is not already running
+				if (!interp.isRunning(stack, target)) interp.toggleThread(stack, target);
 			}
 		}
 		allStacksAndOwnersDo(startMatchingKeyHats);
@@ -511,10 +512,8 @@ public class ScratchRuntime {
 		var ch:int = evt.charCode;
 		if (evt.charCode == 0) ch = mapArrowKey(evt.keyCode);
 		if ((65 <= ch) && (ch <= 90)) ch += 32; // map A-Z to a-z
-		if (ch < 128) {
-			if (!(evt.target is TextField) && !keyIsDown[ch]) startKeyHats(ch);
-			keyIsDown[ch] = true;
-		}
+		if (!(evt.target is TextField)) startKeyHats(ch);
+		if (ch < 128) keyIsDown[ch] = true;
 	}
 
 	public function keyUp(evt:KeyboardEvent):void {


### PR DESCRIPTION
Restarting those stacks would break some uses of whenKeyPressed. We need to continue discussing the design.
