### PR TITLE
Don't overwrite the MD5 of a costume that failed to load.

### DIFF
--- a/src/util/ProjectIO.as
+++ b/src/util/ProjectIO.as
@@ -425,7 +425,13 @@ public class ProjectIO {
 			for each (var c:ScratchCostume in obj.costumes) {
 				data = assetDict[c.baseLayerMD5];
 				if (data) c.baseLayerData = data;
-				else c.baseLayerData = ScratchCostume.emptySVG(); // missing asset data; use empty costume
+				else {
+					// Asset failed to load so use an empty costume
+					// BUT retain the original MD5 and don't break the reference to the costume that failed to load.
+					var origMD5:String = c.baseLayerMD5;
+					c.baseLayerData = ScratchCostume.emptySVG();
+					c.baseLayerMD5 = origMD5;
+				}
 				if (c.textLayerMD5) c.textLayerData = assetDict[c.textLayerMD5];
 			}
 			for each (var snd:ScratchSound in obj.sounds) {


### PR DESCRIPTION
I hope this helps with the empty costume issues we're having (#403).
