### PR TITLE
Change the block category when the mouse clicks instead of on mouse_up

### DIFF
--- a/src/ui/PaletteSelectorItem.as
+++ b/src/ui/PaletteSelectorItem.as
@@ -43,7 +43,7 @@ public class PaletteSelectorItem extends Sprite {
 		setSelected(false);
 		addEventListener(MouseEvent.MOUSE_OVER, mouseOver);
 		addEventListener(MouseEvent.MOUSE_OUT, mouseOut);
-		addEventListener(MouseEvent.MOUSE_UP, mouseUp);
+		addEventListener(MouseEvent.CLICK, mouseUp);
 	}
 
 	private function addLabel(s:String):void {


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-flash/issues/554
