### PR TITLE
Use Flash 11's Sound::loadCompressedDataFromByteArray to load MP3 files

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -59,7 +59,7 @@ import watchers.ListWatcher;
 
 public class Scratch extends Sprite {
 	// Version
-	public static const versionString:String = 'v429';
+	public static const versionString:String = 'v429a';
 	public static var app:Scratch; // static reference to the app, used for debugging
 
 	// Display modes

--- a/src/scratch/ScratchSound.as
+++ b/src/scratch/ScratchSound.as
@@ -30,11 +30,10 @@
 
 package scratch {
 import by.blooddy.crypto.MD5;
-
 import flash.utils.*;
-	import sound.*;
-	import sound.mp3.MP3Loader;
-	import util.*;
+import sound.*;
+import sound.mp3.MP3Loader;
+import util.*;
 
 public class ScratchSound {
 

--- a/src/sound/mp3/MP3Loader.as
+++ b/src/sound/mp3/MP3Loader.as
@@ -43,7 +43,7 @@ public class MP3Loader {
 		load(sndData, loaded);
 	}
 
-	private static function extractSamples(sndName:String, mp3Snd:Sound, mp3SampleCount:int, whenDone:Function):void {
+	public static function extractSamples(sndName:String, mp3Snd:Sound, mp3SampleCount:int, whenDone:Function):void {
 		// Extract the samples from the given mp3 Sound object and convert them into
 		// a ScratchSound object, merging stereo channels and downsampling to 22050 samples/second
 		// if needed. When finished, call whenDone with the new ScratchSound.

--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -673,11 +673,16 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 			SCRATCH::allow3d {
 				sound = new Sound();
 				data.position = 0;
-				sound.loadCompressedDataFromByteArray(data, data.length);
-				MP3Loader.extractSamples(name, sound, sound.length * 44.1, function (out:ScratchSound):void {
-					snd = out;
-					startSoundUpload(out, origName, uploadComplete);
-				});
+				try {
+					sound.loadCompressedDataFromByteArray(data, data.length);
+					MP3Loader.extractSamples(name, sound, sound.length * 44.1, function (out:ScratchSound):void {
+						snd = out;
+						startSoundUpload(out, origName, uploadComplete);
+					});
+				}
+				catch(e:Error) {
+					uploadComplete();
+				}
 			}
 
 			if (!sound)

--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -18,19 +18,19 @@
  */
 
 package ui.media {
-	import flash.display.*;
-	import flash.events.*;
-	import flash.net.*;
-	import flash.text.*;
-	import flash.ui.*;
-	import flash.utils.*;
-	import assets.Resources;
-	import extensions.ScratchExtension;
-	import scratch.*;
-	import sound.mp3.MP3Loader;
-	import translation.Translator;
-	import uiwidgets.*;
-	import util.*;
+import flash.display.*;
+import flash.events.*;
+import flash.media.Sound;
+import flash.net.*;
+import flash.text.*;
+import flash.utils.*;
+import assets.Resources;
+import extensions.ScratchExtension;
+import scratch.*;
+import sound.mp3.MP3Loader;
+import translation.Translator;
+import uiwidgets.*;
+import util.*;
 
 public class MediaLibrary extends Sprite {
 
@@ -669,12 +669,24 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 			startSoundUpload(snd, origName, uploadComplete);
 		} else { // try to read data as an MP3 file
 			if (app.lp) app.lp.setTitle('Converting mp3...');
-			setTimeout(function():void {
-				MP3Loader.convertToScratchSound(sndName, data, function(s:ScratchSound):void {
-					snd = s;
-					startSoundUpload(s, origName, uploadComplete);
+			var sound:Sound;
+			SCRATCH::allow3d {
+				sound = new Sound();
+				data.position = 0;
+				sound.loadCompressedDataFromByteArray(data, data.length);
+				MP3Loader.extractSamples(name, sound, sound.length * 44.1, function (out:ScratchSound):void {
+					snd = out;
+					startSoundUpload(out, origName, uploadComplete);
 				});
-			}, 1);
+			}
+
+			if (!sound)
+				setTimeout(function():void {
+					MP3Loader.convertToScratchSound(sndName, data, function(s:ScratchSound):void {
+						snd = s;
+						startSoundUpload(s, origName, uploadComplete);
+					});
+				}, 1);
 		}
 	}
 


### PR DESCRIPTION
When available, use this method to load MP3s instead of our custom build-a-swf-in-memory method. For those with newer Flash versions this will fix https://github.com/LLK/scratch-flash/issues/206.
