### PR TITLE
Add null check on buffer disposal for fx change

### DIFF
--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -425,8 +425,10 @@ public class DisplayObjectContainerIn3D extends Sprite implements IRenderIn3D {S
 			switchShaders();
 
 			// Throw away the old vertex buffer: it might have the wrong number of streams activated
-			vertexBuffer.dispose();
-			vertexBuffer = null;
+			if (vertexBuffer != null) {
+				vertexBuffer.dispose();
+				vertexBuffer = null;
+			}
 		}
 
 		checkBuffers();


### PR DESCRIPTION
This fixes an exception that was being thrown when toggling 3D off and back on with control-M.
