### PR TITLE
Check for HTTPS also when determining if offline

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -121,7 +121,7 @@ public class Scratch extends Sprite {
 	}
 
 	protected function initialize():void {
-		isOffline = loaderInfo.url.indexOf('http:') == -1;
+		isOffline = loaderInfo.url.indexOf('http:') == -1 && loaderInfo.url.indexOf('https:') == -1;
 		checkFlashVersion();
 		initServer();
 


### PR DESCRIPTION
When viewing a project on https://scratch.mit.edu/, the project editor is in the space where the player should be, and see inside is broken:
![screen shot 2014-12-24 at 8 56 25 am](https://cloud.githubusercontent.com/assets/5834370/5548901/d0f2eea0-8b4a-11e4-9ddf-56b967933a19.png)
This has been reported multiple times on the forums, and checking for both HTTP and HTTPS when determining whether to default to the player or not should fix the problem.