### PR TITLE
Force an update to the 3d renderer when a sprite is added to the stage.

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -970,6 +970,7 @@ public class Scratch extends Sprite {
 		spr.setScratchXY(int(200 * Math.random() - 100), int(100 * Math.random() - 50));
 		if (atMouse) spr.setScratchXY(stagePane.scratchMouseX(), stagePane.scratchMouseY());
 		stagePane.addChild(spr);
+		spr.updateCostume();
 		selectSprite(spr);
 		setTab(showImages ? 'images' : 'scripts');
 		setSaveNeeded(true);

--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -59,7 +59,7 @@ import watchers.ListWatcher;
 
 public class Scratch extends Sprite {
 	// Version
-	public static const versionString:String = 'v431';
+	public static const versionString:String = 'v432';
 	public static var app:Scratch; // static reference to the app, used for debugging
 
 	// Display modes


### PR DESCRIPTION
This fixes an issue where recently added bitmap sprites appear invisible when the 3d renderer is in use.