### PR TITLE
Store eraser width separately from pen width

### DIFF
--- a/src/svgeditor/DrawProperties.as
+++ b/src/svgeditor/DrawProperties.as
@@ -35,20 +35,32 @@ public class DrawProperties {
 	// stroke
 	public var smoothness:Number = 1;
 	private var rawStrokeWidth:Number = 1;
+	private var rawEraserWidth:Number = 4;
 
 	public function set strokeWidth(w:int):void { rawStrokeWidth = w }
+	public function set eraserWidth(w:int):void { rawEraserWidth = w }
 
 	public function get strokeWidth():int {
-		if (Scratch.app.imagesPart && (Scratch.app.imagesPart.editor is SVGEdit)) return rawStrokeWidth;
+		return adjustWidth(rawStrokeWidth);
+	}
+
+	public function get eraserWidth():int {
+		return adjustWidth(rawEraserWidth);
+	}
+
+	private static function adjustWidth(raw:int):int {
+		if (Scratch.app.imagesPart && (Scratch.app.imagesPart.editor is SVGEdit)) return raw;
 
 		// above 10, use Squeak brush sizes
-		var n:Number = Math.max(1, Math.round(rawStrokeWidth));
-		if (11 == n) return 13;
-		if (12 == n) return 19;
-		if (13 == n) return 29;
-		if (14 == n) return 47;
-		if (15 == n) return 75;
-		return n;
+		const n:Number = Math.max(1, Math.round(raw));
+		switch(n) {
+			case 11: return 13;
+			case 12: return 19;
+			case 13: return 29;
+			case 14: return 47;
+			case 15: return 75;
+			default: return n;
+		}
 	}
 
 	// fill

--- a/src/svgeditor/DrawPropertyUI.as
+++ b/src/svgeditor/DrawPropertyUI.as
@@ -145,7 +145,7 @@ public class DrawPropertyUI extends Sprite {
 	public function set settings(props:DrawProperties):void {
 		currentValues = props;
 		colorPicker.pickColor();
-		strokeWidthSlider.value = props.strokeWidth;
+		strokeWidthSlider.value = eraserStrokeMode ? props.eraserWidth : props.strokeWidth;
 		updateStrokeWidthDisplay();
 	}
 
@@ -208,7 +208,7 @@ public class DrawPropertyUI extends Sprite {
 		strokeWidthSlider.visible = isStroke || isEraser;
 		disableEvents = true;
 		SimpleTooltips.add(strokeWidthSlider.parent, {text: (isEraser ? 'Eraser width' : 'Line width'), direction: 'top'});
-		strokeWidthSlider.value = currentValues.strokeWidth;
+		strokeWidthSlider.value = isEraser ? currentValues.eraserWidth : currentValues.strokeWidth;
 		disableEvents = false;
 		updateStrokeWidthDisplay();
 	}
@@ -442,7 +442,12 @@ public class DrawPropertyUI extends Sprite {
 
 	private function makeStrokeUI():void {
 		function updateStrokeWidth(w:Number):void {
-			currentValues.strokeWidth = w;
+			if (eraserStrokeMode) {
+				currentValues.eraserWidth = w;
+			}
+			else {
+				currentValues.strokeWidth = w;
+			}
 			updateStrokeWidthDisplay();
 			sendChangeEvent();
 		}
@@ -478,7 +483,7 @@ public class DrawPropertyUI extends Sprite {
 	}
 
 	private function updateStrokeWidthDisplay(ignore:* = null):void {
-		var w:Number = currentValues.strokeWidth;
+		var w:Number = eraserStrokeMode ? currentValues.eraserWidth : currentValues.strokeWidth;
 		if (editor is BitmapEdit) {
 			if (19 == w) w = 17;
 			if (29 == w) w = 20;

--- a/src/svgeditor/ImageEdit.as
+++ b/src/svgeditor/ImageEdit.as
@@ -95,6 +95,7 @@ package svgeditor {
 			var initialColors:DrawProperties = new DrawProperties();
 			initialColors.color = 0xFF000000;
 			initialColors.strokeWidth = 2;
+			initialColors.eraserWidth = initialColors.strokeWidth * 4;
 			initialColors.filledShape = (this is BitmapEdit);
 			drawPropsUI.updateUI(initialColors);
 

--- a/src/svgeditor/tools/BitmapPencilTool.as
+++ b/src/svgeditor/tools/BitmapPencilTool.as
@@ -26,8 +26,6 @@ package svgeditor.tools {
 
 public final class BitmapPencilTool extends SVGTool {
 
-	private static const ERASER_SCALE:int = 4; // scale the eraser size by this much to make it easier to use
-
 	private var eraseMode:Boolean;	// true if this is the eraser tool
 
 	// brush/eraser properties
@@ -126,8 +124,7 @@ public final class BitmapPencilTool extends SVGTool {
 
 	private function getPenProps():void {
 		var props:DrawProperties = editor.getShapeProps();
-		brushSize = Math.max(1, 2 * Math.round(props.strokeWidth));
-		if (eraseMode) brushSize *= ERASER_SCALE;
+		brushSize = Math.max(1, 2 * Math.round(eraseMode ? props.eraserWidth : props.strokeWidth));
 		brushColor = (props.alpha > 0) ? (0xFF000000 | props.color) : 0;
 	}
 

--- a/src/svgeditor/tools/EraserTool.as
+++ b/src/svgeditor/tools/EraserTool.as
@@ -51,8 +51,7 @@ package svgeditor.tools
 	{
 		private var eraserShape:Shape;
 		private var lastPos:Point;
-		private var origStrokeWidth:Number;
-		private var strokeWidth:Number;
+		private var eraserWidth:Number;
 		private var erased:Boolean;
 		public function EraserTool(ed:ImageEdit) {
 			super(ed);
@@ -66,11 +65,11 @@ package svgeditor.tools
 
 		public function updateIcon():void {
 			var sp:DrawProperties = editor.getShapeProps();
-			if(strokeWidth != sp.strokeWidth) {
+			if(eraserWidth != sp.eraserWidth) {
 				var bm:Bitmap = Resources.createBmp('eraserOff');
 				var s:Shape = new Shape();
 				s.graphics.lineStyle(1);
-				s.graphics.drawCircle(0, 0, sp.strokeWidth * 0.65);
+				s.graphics.drawCircle(0, 0, sp.eraserWidth * 0.65);
 				var curBM:BitmapData = new BitmapData(32, 32, true, 0);
 				var m:Matrix = new Matrix();
 				m.translate(16, 18);
@@ -78,7 +77,7 @@ package svgeditor.tools
 				m.translate(-cursorHotSpot.x, -cursorHotSpot.y);
 				curBM.draw(bm, m);
 				editor.setCurrentCursor('eraserOff', curBM, new Point(16, 18), false);
-				strokeWidth = sp.strokeWidth;
+				eraserWidth = sp.eraserWidth;
 			}
 		}
 
@@ -87,12 +86,10 @@ package svgeditor.tools
 			editor.getWorkArea().addEventListener(MouseEvent.MOUSE_DOWN, mouseDown, false, 0, true);
 			stage.addChild(eraserShape);
 			updateIcon();
-			origStrokeWidth = editor.getShapeProps().strokeWidth;
 		}
 
 		override protected function shutdown():void {
 			editor.getWorkArea().removeEventListener(MouseEvent.MOUSE_DOWN, mouseDown);
-			editor.getShapeProps().strokeWidth = origStrokeWidth;
 			super.shutdown();
 			stage.removeChild(eraserShape);
 		}
@@ -100,7 +97,7 @@ package svgeditor.tools
 		private function mouseDown(e:MouseEvent):void {
 			editor.getWorkArea().addEventListener(MouseEvent.MOUSE_MOVE, erase, false, 0, true);
 			editor.stage.addEventListener(MouseEvent.MOUSE_UP, mouseUp, false, 0, true);
-			strokeWidth = editor.getShapeProps().strokeWidth;
+			eraserWidth = editor.getShapeProps().eraserWidth;
 			erase();
 		}
 
@@ -165,18 +162,18 @@ package svgeditor.tools
 
 		private function updateEraserShape():void {
 			var g:Graphics = eraserShape.graphics;
-			//var w:Number = strokeWidth * editor.getContentLayer().
+			//var w:Number = eraserWidth * editor.getContentLayer().
 			g.clear();
 			var p:Point = new Point(eraserShape.mouseX, eraserShape.mouseY);
 			if(lastPos) {
-				g.lineStyle(strokeWidth, 0xFF0000, 1, false, LineScaleMode.NORMAL, CapsStyle.ROUND);
+				g.lineStyle(eraserWidth, 0xFF0000, 1, false, LineScaleMode.NORMAL, CapsStyle.ROUND);
 				g.moveTo(lastPos.x, lastPos.y);
 				//var p:Point = obj.globalToLocal(lastPos).subtract(new Point(obj.mouseX, obj.mouseY));
 				g.lineTo(p.x, p.y);
 			} else {
 				g.lineStyle(0, 0, 0);
 				g.beginFill(0xFF0000);
-				g.drawCircle(p.x, p.y, strokeWidth * 0.65);
+				g.drawCircle(p.x, p.y, eraserWidth * 0.65);
 				g.endFill();
 				g.moveTo(p.x, p.y);
 			}


### PR DESCRIPTION
The default eraser size is larger than the default pen size, but the limits are currently the same.
This fixes #596