### PR TITLE
Comment layout fix

### DIFF
--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -574,6 +574,7 @@ public class BlockMenus implements DragClient {
 			}
 		}
 		app.runtime.updateCalls();
+		app.scriptsPane.fixCommentLayout();
 		app.updatePalette();
 	}
 


### PR DESCRIPTION
When a user defined block has been edited, and some inputs has been added/removed, the width of the block can change, so we need to call fixCommentLayout.