### PR TITLE
Automatically select text when adding comment

### DIFF
--- a/src/scratch/ScratchComment.as
+++ b/src/scratch/ScratchComment.as
@@ -82,6 +82,11 @@ public class ScratchComment extends Sprite {
 		drawTitleBar();
 	}
 
+	public function startEditText(): void {
+		contents.setSelection(0, contents.text.length);
+		stage.focus = contents;
+	}
+
 	private function drawTitleBar():void {
 		// Draw darker yellow title area used when comment expanded.
 		var g:Graphics = titleBar.graphics;

--- a/src/uiwidgets/ScriptsPane.as
+++ b/src/uiwidgets/ScriptsPane.as
@@ -456,6 +456,7 @@ return true; // xxx disable this check for now; it was causing confusion at Scra
 		addChild(c);
 		saveScripts();
 		updateSize();
+		c.startEditText();
 	}
 
 	public function fixCommentLayout():void {


### PR DESCRIPTION
When the user adds a comment to a block, it would be convenient to have the text "add comment here..." selected and the TextField focused.