### PR TITLE
Allowing sprites to go outside or partly outside the stage.

### DIFF
--- a/src/primitives/MotionAndPenPrims.as
+++ b/src/primitives/MotionAndPenPrims.as
@@ -293,7 +293,6 @@ public class MotionAndPenPrims {
 		var oldX:Number = s.scratchX;
 		var oldY:Number = s.scratchY;
 		s.setScratchXY(newX, newY);
-		s.keepOnStage();
 		if (s.penIsDown) stroke(s, oldX, oldY, s.scratchX, s.scratchY);
 		if ((s.penIsDown) || (s.visible)) interp.redraw();
 	}

--- a/src/scratch/ScratchSprite.as
+++ b/src/scratch/ScratchSprite.as
@@ -182,40 +182,6 @@ public class ScratchSprite extends ScratchObj {
 	static private var stageRect:Rectangle = new Rectangle(0, 0, 480, 360);
 	static private var emptyRect:Rectangle = new Rectangle(0, 0, 0, 0);
 	static private var edgeBox:Rectangle = new Rectangle(0, 0, 480, 360);
-	public function keepOnStage():void {
-		var myBox:Rectangle;
-		if(width == 0 && height == 0) {
-			emptyRect.x = x;
-			emptyRect.y = y;
-			myBox = emptyRect;
-		}
-		else {
-			myBox = geomShape.getRect(parent);
-			if(myBox.width == 0 || myBox.height == 0) {
-				myBox.x = x;
-				myBox.y = y;
-			}
-			myBox.inflate(3, 3);
-		}
-
-		if(stageRect.containsRect(myBox)) return;
-
-		var inset:int = Math.min(18, Math.min(myBox.width, myBox.height) / 2);
-		edgeBox.x = edgeBox.y = inset;
-		inset += inset;
-		edgeBox.width = 480 - inset;
-		edgeBox.height = 360 - inset;
-		if (myBox.intersects(edgeBox)) return; // sprite is sufficiently on stage
-		if (myBox.right < edgeBox.left)
-			scratchX = Math.ceil(scratchX + (edgeBox.left - myBox.right));
-		if (myBox.left > edgeBox.right)
-			scratchX = Math.floor(scratchX + (edgeBox.right - myBox.left));
-		if (myBox.bottom < edgeBox.top)
-			scratchY = Math.floor(scratchY + (myBox.bottom - edgeBox.top));
-		if (myBox.top > edgeBox.bottom)
-			scratchY = Math.ceil(scratchY + (myBox.top - edgeBox.bottom));
-		setScratchXY(scratchX, scratchY);
-	}
 
 	public function setDirection(d:Number):void {
 		if ((d * 0) != 0) return; // d is +/-Infinity or NaN


### PR DESCRIPTION
Sprites should be able to go outside the stage. Else, a lot of effects are impossible. In my remix of Dog-a-thon at http://scratch.mit.edu/projects/45942694/ , the stones should not all start at the left edge of the screen, but at an x-coordinate to the left of the edge. They should also be able to leave the right edge. With the current version that is impossible to do because of the function ScratchSprite.keepOnStage.