### PR TITLE
Underlines global variables in the script palette.

### DIFF
--- a/src/RenderedVariable.as
+++ b/src/RenderedVariable.as
@@ -1,0 +1,35 @@
+/*
+ * Scratch Project Editor and Player
+ * Copyright (C) 2014 Massachusetts Institute of Technology
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// RenderedVariable.as
+// Anders Lindén, February 2015
+//
+// A RenderedVariable object is having a short lifetime and is only used to
+// couple name with the scope, so that global variables can appear underlined
+
+package {
+	public class RenderedVariable {
+		public var name:String;
+		public var local:Boolean;
+		public function RenderedVariable(name:String, local:Boolean):void {
+			this.name = name;
+			this.local = local;
+		}
+	}
+}

--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -105,7 +105,7 @@ public class Block extends Sprite {
 
 	private var originalParent:DisplayObjectContainer, originalRole:int, originalIndex:int, originalPosition:Point;
 
-	public function Block(spec:String, type:String = " ", color:int = 0xD00000, op:* = 0, defaultArgs:Array = null) {
+	public function Block(spec:String, type:String = " ", color:int = 0xD00000, op:* = 0, defaultArgs:Array = null, underlined:Boolean = false) {
 		this.spec = Translator.map(spec);
 		this.type = type;
 		this.op = op;
@@ -167,12 +167,12 @@ public class Block extends Sprite {
 			base = new BlockShape(BlockShape.RectShape, color);
 		}
 		addChildAt(base, 0);
-		setSpec(this.spec, defaultArgs);
+		setSpec(this.spec, defaultArgs, underlined);
 
 		addEventListener(FocusEvent.KEY_FOCUS_CHANGE, focusChange);
 	}
 
-	public function setSpec(newSpec:String, defaultArgs:Array = null):void {
+	public function setSpec(newSpec:String, defaultArgs:Array = null, underlined:Boolean = false):void {
 		for each (var o:DisplayObject in labelsAndArgs) {
 			if (o.parent != null) o.parent.removeChild(o);
 		}
@@ -191,7 +191,9 @@ public class Block extends Sprite {
 			var b:Block;
 			labelsAndArgs.push(b = declarationBlock());
 		} else if (op == Specs.GET_VAR || op == Specs.GET_LIST) {
-			labelsAndArgs = [makeLabel(spec)];
+			var label:TextField = makeLabel(spec);
+			label.setTextFormat(new TextFormat(null, null, null, null, null, underlined));
+			labelsAndArgs = [label];
 		} else {
 			const loopBlocks:Array = ['doForever', 'doForeverIf', 'doRepeat', 'doUntil'];
 			base.hasLoopArrow = (loopBlocks.indexOf(op) >= 0);

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -153,11 +153,11 @@ public class PaletteBuilder {
 
 		// variable buttons, reporters, and set/change blocks
 		addItem(new Button(Translator.map('Make a Variable'), makeVariable));
-		var varNames:Array = app.runtime.allVarNames().sort();
+		var varNames:Array = app.runtime.allVarNames().sortOn("name");
 		if (varNames.length > 0) {
-			for each (var n:String in varNames) {
-				addVariableCheckbox(n, false);
-				addItem(new Block(n, 'r', catColor, Specs.GET_VAR), true);
+			for each (var n:RenderedVariable in varNames) {
+				addVariableCheckbox(n.name, false);
+				addItem(new Block(n.name, 'r', catColor, Specs.GET_VAR, null, !n.local), true);
 			}
 			nextY += 10;
 			addBlocksForCategory(Specs.dataCategory, catColor);
@@ -170,9 +170,9 @@ public class PaletteBuilder {
 
 		var listNames:Array = app.runtime.allListNames().sort();
 		if (listNames.length > 0) {
-			for each (n in listNames) {
-				addVariableCheckbox(n, true);
-				addItem(new Block(n, 'r', catColor, Specs.GET_LIST), true);
+			for each (var n:RenderedVariable in listNames) {
+				addVariableCheckbox(n.name, true);
+				addItem(new Block(n.name, 'r', catColor, Specs.GET_LIST), true);
 			}
 			nextY += 10;
 			addBlocksForCategory(Specs.listCategory, catColor);

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -590,9 +590,9 @@ public class ScratchRuntime {
 
 	public function allVarNames():Array {
 		var result:Array = [], v:Variable;
-		for each (v in app.stageObj().variables) result.push(v.name);
+		for each (v in app.stageObj().variables) result.push(new RenderedVariable(v.name, false));
 		if (!app.viewedObj().isStage) {
-			for each (v in app.viewedObj().variables) result.push(v.name);
+			for each (v in app.viewedObj().variables) result.push(new RenderedVariable(v.name, true));
 		}
 		return result;
 	}


### PR DESCRIPTION
To distinguish globals from locals in the script palette, I have added an alternate appearance for globals so that they are underlined. Just an idea of how to make it simpler to get an overview of the variable's scope.