### PR TITLE
Move scroll gesture pickiness to the scripts area

### DIFF
--- a/src/ui/parts/base/BaseScriptsPart.as
+++ b/src/ui/parts/base/BaseScriptsPart.as
@@ -30,18 +30,19 @@ import flash.text.TextField;
 import flash.text.TextFormat;
 import flash.utils.getTimer;
 
+import org.gestouch.core.Touch;
+import org.gestouch.gestures.Gesture;
+import org.gestouch.gestures.TransformGesture;
+
 import scratch.ScratchObj;
 import scratch.ScratchSprite;
 
 import ui.BlockPalette;
-
 import ui.PaletteSelector;
-
 import ui.parts.UIPart;
 
 import uiwidgets.IndicatorLight;
 import uiwidgets.ScriptsPane;
-
 import uiwidgets.ScrollFrame;
 import uiwidgets.ZoomWidget;
 
@@ -80,7 +81,12 @@ public class BaseScriptsPart extends UIPart implements IScriptsPart {
 		addChild(paletteFrame);
 
 		var scriptsPane:ScriptsPane = getScriptsPane();
-		scriptsFrame = new ScrollFrame(dragScroll);
+		scriptsFrame = new ScrollFrame(false);
+		if (dragScroll) {
+			var scriptsScrollGesture:TransformGesture = new TransformGesture();
+			scriptsScrollGesture.gestureShouldReceiveTouchCallback = shouldScriptsScrollReceiveTouch;
+			scriptsFrame.enableDragScrolling(scriptsScrollGesture);
+		}
 		scriptsFrame.setContents(scriptsPane);
 		addChild(scriptsFrame);
 
@@ -96,6 +102,10 @@ public class BaseScriptsPart extends UIPart implements IScriptsPart {
 
 	protected function getScriptsPane():ScriptsPane {
 		return new ScriptsPane(app);
+	}
+
+	protected function shouldScriptsScrollReceiveTouch(gesture:Gesture, touch:Touch):Boolean {
+		return touch.target == scriptsFrame || touch.target == scriptsFrame.contents;
 	}
 
 	// Derived classes need to actually do something with the layout

--- a/src/uiwidgets/ScrollFrame.as
+++ b/src/uiwidgets/ScrollFrame.as
@@ -38,9 +38,7 @@ import flash.events.Event;
 import flash.events.MouseEvent;
 import flash.filters.GlowFilter;
 
-import org.gestouch.core.Touch;
 import org.gestouch.events.GestureEvent;
-import org.gestouch.gestures.Gesture;
 import org.gestouch.gestures.TransformGesture;
 
 public class ScrollFrame extends Sprite {
@@ -87,9 +85,12 @@ public class ScrollFrame extends Sprite {
 	}
 
 	public function enableDragScrolling(dragGesture:TransformGesture = null):void {
-		panGesture = dragGesture || new TransformGesture(this);
-		if (!panGesture.gestureShouldReceiveTouchCallback) {
-			panGesture.gestureShouldReceiveTouchCallback = shouldPanReceiveTouch;
+		if (dragGesture) {
+			panGesture = dragGesture;
+			panGesture.target = this;
+		}
+		else {
+			panGesture = new TransformGesture(this);
 		}
 		panGesture.addEventListener(GestureEvent.GESTURE_BEGAN, onPanGestureBegan);
 		panGesture.addEventListener(GestureEvent.GESTURE_CHANGED, onPanGestureChanged);
@@ -255,10 +256,6 @@ public class ScrollFrame extends Sprite {
 	public function constrainScroll():void {
 		contents.x = Math.max(-maxScrollH(), Math.min(contents.x, 0));
 		contents.y = Math.max(-maxScrollV(), Math.min(contents.y, 0));
-	}
-
-	protected function shouldPanReceiveTouch(gesture:Gesture, touch:Touch):Boolean {
-		return touch.target == this || touch.target == this.contents;
 	}
 
 	protected function onPanGestureBegan(event:GestureEvent):void {


### PR DESCRIPTION
Most ScrollFrames are OK with catching the drag event from a child, so
move the code that prevents that into the scripts part. Any other scroll
frame that wants to prevent it can follow this pattern.