### PR TITLE
Use drawWithQuality, don't change stage quality

### DIFF
--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -503,10 +503,7 @@ public class ScratchCostume {
 		if (!forStage) m.translate(-dispR.x, -dispR.y);
 		m.scale(scale, scale);
 
-		var oldQuality:String = Scratch.app.stage.quality;
-		Scratch.app.stage.quality = StageQuality.LOW;
-		bm.draw(dispObj, m);
-		Scratch.app.stage.quality = oldQuality;
+		bm.drawWithQuality(dispObj, m, null, null, null, false, StageQuality.LOW);
 
 		return bm;
 	}


### PR DESCRIPTION
Changing the stage quality sometimes triggers a resize event. If this happens while converting a costume from vector to bitmap the image editor is shut down in the middle of the conversion, causing a crash.

I was unable to determine the reason that changing the stage quality sometimes fires a resize event and sometimes doesn't, but using drawWithQuality is probably more efficient anyway.