### PR TITLE
Convert to bitmap crash fix

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -71,7 +71,7 @@ public class Scratch extends Sprite {
 	public var render3D:IRenderIn3D;
 	public var isArmCPU:Boolean;
 	public var jsEnabled:Boolean = false; // true when the SWF can talk to the webpage
-	public var ignoreResize:int = 0; // If non-zero, temporarily ignore resize events.
+	public var ignoreResize:Boolean = false; // If true, temporarily ignore resize events.
 
 	// Runtime
 	public var runtime:ScratchRuntime;

--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -71,6 +71,7 @@ public class Scratch extends Sprite {
 	public var render3D:IRenderIn3D;
 	public var isArmCPU:Boolean;
 	public var jsEnabled:Boolean = false; // true when the SWF can talk to the webpage
+	public var ignoreResize:int = 0; // If non-zero, temporarily ignore resize events.
 
 	// Runtime
 	public var runtime:ScratchRuntime;
@@ -597,7 +598,7 @@ public class Scratch extends Sprite {
 	protected function isShowing(obj:DisplayObject):Boolean { return obj.parent != null }
 
 	public function onResize(e:Event):void {
-		fixLayout();
+		if (!ignoreResize) fixLayout();
 	}
 
 	public function fixLayout():void {

--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -507,12 +507,12 @@ public class ScratchCostume {
 			bm.drawWithQuality(dispObj, m, null, null, null, false, StageQuality.LOW);
 		}
 		else {
-			++Scratch.app.ignoreResize;
+			Scratch.app.ignoreResize = true;
 			var oldQuality:String = Scratch.app.stage.quality;
 			Scratch.app.stage.quality = StageQuality.LOW;
 			bm.draw(dispObj, m);
 			Scratch.app.stage.quality = oldQuality;
-			--Scratch.app.ignoreResize;
+			Scratch.app.ignoreResize = false;
 		}
 
 		return bm;

--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -503,7 +503,17 @@ public class ScratchCostume {
 		if (!forStage) m.translate(-dispR.x, -dispR.y);
 		m.scale(scale, scale);
 
-		bm.drawWithQuality(dispObj, m, null, null, null, false, StageQuality.LOW);
+		if (SCRATCH::allow3d) {
+			bm.drawWithQuality(dispObj, m, null, null, null, false, StageQuality.LOW);
+		}
+		else {
+			++Scratch.app.ignoreResize;
+			var oldQuality:String = Scratch.app.stage.quality;
+			Scratch.app.stage.quality = StageQuality.LOW;
+			bm.draw(dispObj, m);
+			Scratch.app.stage.quality = oldQuality;
+			--Scratch.app.ignoreResize;
+		}
 
 		return bm;
 	}

--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -503,10 +503,7 @@ public class ScratchCostume {
 		if (!forStage) m.translate(-dispR.x, -dispR.y);
 		m.scale(scale, scale);
 
-		var oldQuality:String = Scratch.app.stage.quality;
-		Scratch.app.stage.quality = StageQuality.LOW;
-		bm.draw(dispObj, m);
-		Scratch.app.stage.quality = oldQuality;
+		bm.drawWithQuality(dispObj, m, null, null, null, false, StageQuality.LOW);
 
 		return bm;
 	}


### PR DESCRIPTION
This change fixes a crash that can sometimes happen while converting a vector costume into a bitmap costume. The fix is different depending on whether Scratch is running a newer or older version of Flash.

The problem stems from changing the stage quality when rendering the SVG into a bitmap. Changing the stage quality sometimes -- but not always -- fires a 'resize' event that is caught in Scratch.as, causing the image editor to be shut down in the middle of the conversion. The actual crash happens inside BitmapEdit's saveToCostume() method, where targetCostume is unexpectedly null.

On newer versions of Flash we now use drawWithQuality() to avoid the need to change the stage's quality.

On older versions of Flash we now set a flag to suppress the resize event, and clear that flag after the rendering step completes.