### PR TITLE
Debug blocks

### DIFF
--- a/src/Specs.as
+++ b/src/Specs.as
@@ -28,6 +28,7 @@
 package {
 	import flash.display.Bitmap;
 	import assets.Resources;
+	import util.DebugUtils;
 
 public class Specs {
 
@@ -48,12 +49,14 @@ public class Specs {
 	public static const myBlocksCategory:int = 10;
 	public static const listCategory:int = 12;
 	public static const extensionsCategory:int = 20;
+	public static const debugCategory:int = 999;
 
 	public static var variableColor:int = 0xEE7D16; // Scratch 1.4: 0xF3761D
 	public static var listColor:int = 0xCC5B22; // Scratch 1.4: 0xD94D11
 	public static var procedureColor:int = 0x632D99; // 0x531E99;
 	public static var parameterColor:int = 0x5947B1;
 	public static var extensionsColor:int = 0x4B4A60; // 0x72228C; // 0x672D79;
+	public static var debugColor:int = 0xA0A0A0;
 
 	private static const undefinedColor:int = 0xD42828;
 
@@ -72,7 +75,7 @@ public class Specs {
 		[10, "More Blocks",	procedureColor],
 		[11, "Parameter",	parameterColor],
 		[12, "List",		listColor],
-		[20, "Extension",	extensionsColor],
+		[20, "Extension",	extensionsColor]
 	];
 
 	public static function blockColor(categoryID:int):int {
@@ -392,9 +395,21 @@ public class Specs {
 
 		// other obsolete blocks from alpha/beta
 		["hide all sprites",					" ", 99, "hideAll"],
-		["user id",								"r", 99, "getUserId"],
+		["user id",								"r", 99, "getUserId"]
 
 	];
+
+	if (DebugUtils.IsDebug) {
+		commands.push(["trace %s", " ", 13, "trace:"]);
+		commands.push(["version", "r", 13, "version"]);
+		commands.push(["os", "r", 13, "os"]);
+		commands.push(["player type", "r", 13, "playertype"]);
+		commands.push(["language", "r", 13, "language"]);
+		commands.push(["manufacturer", "r", 13, "manufacturer"]);
+		commands.push(["has mp3?", "b", 13, "hasmp3"]);
+
+		categories.push([13, "Debug", debugColor]);
+	}
 
 	public static var extensionSpecs:Array = ["when %m.booleanSensor", "when %m.sensor %m.lessMore %n", "sensor %m.booleanSensor?", "%m.sensor sensor value", "turn %m.motor on for %n secs", "turn %m.motor on", "turn %m.motor off", "set %m.motor power to %n", "set %m.motor2 direction to %m.motorDirection", "when distance %m.lessMore %n", "when tilt %m.eNe %n", "distance", "tilt"];
 

--- a/src/primitives/LooksPrims.as
+++ b/src/primitives/LooksPrims.as
@@ -27,6 +27,7 @@ package primitives {
 	import blocks.*;
 	import interpreter.*;
 	import scratch.*;
+	import util.DebugUtils;
 
 public class LooksPrims {
 
@@ -56,6 +57,10 @@ public class LooksPrims {
 		primTable['say:']							= function(b:*):* { showBubble(b, 'talk') };
 		primTable['think:duration:elapsed:from:']	= function(b:*):* { showBubbleAndWait(b, 'think') };
 		primTable['think:']							= function(b:*):* { showBubble(b, 'think') };
+
+		if (DebugUtils.IsDebug) {
+			primTable['trace:'] = function(b:Block):* { trace(interp.arg(b, 0)) };
+		}
 
 		primTable['changeGraphicEffect:by:'] = primChangeEffect;
 		primTable['setGraphicEffect:to:']	= primSetEffect;

--- a/src/primitives/SensingPrims.as
+++ b/src/primitives/SensingPrims.as
@@ -29,6 +29,7 @@ package primitives {
 	import blocks.Block;
 	import interpreter.*;
 	import scratch.*;
+	import util.DebugUtils;
 
 public class SensingPrims {
 
@@ -72,6 +73,16 @@ public class SensingPrims {
 		primTable['hideVariable:']		= primHideWatcher;
 		primTable['showList:']			= primShowListWatcher;
 		primTable['hideList:']			= primHideListWatcher;
+
+		if (DebugUtils.IsDebug) {
+			primTable['version'] = function(b:*):* { return DebugUtils.version; };
+			primTable['os'] = function(b:*):* { return DebugUtils.os; };
+			primTable['playertype'] = function(b:*):* { return DebugUtils.playerType; };
+			primTable['language'] = function(b:*):* { return DebugUtils.language; };
+			primTable['manufacturer'] = function(b:*):* { return DebugUtils.manufacturer; };
+			primTable['hasmp3'] = function(b:*):* { return DebugUtils.hasmp3; };
+		}
+
 	}
 
 	// TODO: move to stage

--- a/src/ui/PaletteSelector.as
+++ b/src/ui/PaletteSelector.as
@@ -28,12 +28,17 @@ package ui {
 	import flash.display.*;
 	import translation.Translator;
 	import scratch.PaletteBuilder;
+	import util.DebugUtils;
 
 public class PaletteSelector extends Sprite {
 
 	private static const categories:Array = [
 		'Motion', 'Looks', 'Sound', 'Pen', 'Data', // column 1
 		'Events', 'Control', 'Sensing', 'Operators', 'More Blocks']; // column 2
+
+	if (DebugUtils.IsDebug) {
+		categories.push("Debug");
+	}
 
 	public var selectedCategory:int = 0;
 	private var app:Scratch;

--- a/src/util/DebugUtils.as
+++ b/src/util/DebugUtils.as
@@ -22,6 +22,7 @@ package util {
 import flash.utils.getQualifiedClassName;
 import flash.display.DisplayObjectContainer;
 import flash.display.DisplayObject;
+import flash.system.Capabilities;
 
 public class DebugUtils {
 
@@ -40,6 +41,34 @@ public class DebugUtils {
 		for (i = 0; i < container.numChildren; i++) {
 			printSubtree(container.getChildAt(i), indent + 1, out);
 		}
+	}
+
+	public static function get IsDebug():Boolean {
+		return Capabilities.isDebugger && new Error().getStackTrace().search(/:[0-9]+]$/m) > -1;
+	}
+
+	public static function get version(): String {
+		return Capabilities.version;
+	}
+
+	public static function get os(): String {
+		return Capabilities.os;
+	}
+
+	public static function get playerType(): String {
+		return Capabilities.playerType;
+	}
+
+	public static function get language(): String {
+		return Capabilities.language;
+	}
+
+	public static function get hasmp3(): Boolean {
+		return Capabilities.hasMP3;
+	}
+
+	public static function get manufacturer(): String {
+		return Capabilities.manufacturer;
 	}
 
 }}


### PR DESCRIPTION
Adding some blocks that can be used when the player runs in debug mode.
Those are: trace, sensors/reporters for version, os, player type, language, manufacturer and has mp3.
Maybe this is totally uninteresting so I will not blame you if you close this pull request without excuses.
I learned something about blocks and reporters when writing it however.