### PR TITLE
Media library refactor

### DIFF
--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -86,7 +86,7 @@ public class ScratchCostume {
 	public var undoList:Array = [];
 	public var undoListIndex:int;
 
-	public function ScratchCostume(name:String, data:*, centerX:int = 99999, centerY:int = 99999) {
+	public function ScratchCostume(name:String, data:*, centerX:int = 99999, centerY:int = 99999, bmRes:int = 1) {
 		costumeName = name;
 		rotationCenterX = centerX;
 		rotationCenterY = centerY;
@@ -94,6 +94,7 @@ public class ScratchCostume {
 			rotationCenterX = rotationCenterY = 0;
 		} else if (data is BitmapData) {
 			bitmap = baseLayerBitmap = data;
+			bitmapResolution = bmRes;
 			if (centerX == 99999) rotationCenterX = bitmap.rect.width / 2;
 			if (centerY == 99999) rotationCenterY = bitmap.rect.height / 2;
 			prepareToSave();

--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -75,7 +75,7 @@ public class MediaLibrary extends Sprite {
 	private var okayButton:Button;
 	private var cancelButton:Button;
 
-	private static var libraryCache:Array; // cache of all mediaLibrary entries
+	private static var libraryCache:Object = {}; // cache of all mediaLibrary entries
 
 	public function MediaLibrary(app:Scratch, type:String, whenDone:Function) {
 		this.app = app;
@@ -287,19 +287,19 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 		function gotLibraryData(data:ByteArray):void {
 			if (!data) return; // failure
 			var s:String = data.readUTFBytes(data.length);
-			libraryCache = util.JSON.parse(stripComments(s)) as Array;
+			libraryCache[assetType] = util.JSON.parse(stripComments(s)) as Array;
 			collectEntries();
 		}
 		function collectEntries():void {
 			allItems = [];
-			for each (var entry:Object in libraryCache) {
+			for each (var entry:Object in libraryCache[assetType]) {
 				if (entry.type == assetType) {
 					if (entry.tags is Array) entry.category = entry.tags[0];
 					var info:Array = entry.info as Array;
 					if (info) {
 						if ((entry.type == 'backdrop') || (assetType == 'costume')) {
-							entry.width = info[0];
-							entry.height = info[1];
+//							entry.width = info[0];
+//							entry.height = info[1];
 						}
 						if (entry.type == 'sound') {
 							entry.seconds = info[0];
@@ -320,7 +320,7 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 			addScratchExtensions();
 			return;
 		}
-		if (!libraryCache) app.server.getMediaLibrary(gotLibraryData);
+		if (!libraryCache[assetType]) app.server.getMediaLibrary(assetType, gotLibraryData);
 		else collectEntries();
 	}
 

--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -429,7 +429,14 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 				} else if (assetType == 'sound') {
 					io.fetchSound(md5AndExt, item.dbObj.name, whenDone);
 				} else {
-					io.fetchImage(md5AndExt, item.dbObj.name, 0, whenDone);
+					var obj:Object = {
+						centerX: item.dbObj.info[0],
+						centerY: item.dbObj.info[1],
+						bitmapResolution: 1
+					};
+					if (item.dbObj.info.length == 3)
+						obj.bitmapResolution = item.dbObj.info[2];
+					io.fetchImage(md5AndExt, item.dbObj.name, 0, whenDone, obj);
 				}
 			}
 		}

--- a/src/util/IServer.as
+++ b/src/util/IServer.as
@@ -33,7 +33,7 @@ public interface IServer {
 	// Asset API
 	//------------------------------
 	function getAsset(md5:String, callback:Function):URLLoader;
-	function getMediaLibrary(callback:Function):URLLoader;
+	function getMediaLibrary(type:String, callback:Function):URLLoader;
 	function getThumbnail(md5:String, w:int, h:int, callback:Function):URLLoader;
 
 	// -----------------------------

--- a/src/util/ProjectIO.as
+++ b/src/util/ProjectIO.as
@@ -309,7 +309,7 @@ public class ProjectIO {
 	// Fetch a costume or sound from the server
 	//----------------------------
 
-	public function fetchImage(id:String, costumeName:String, width:int, whenDone:Function):URLLoader {
+	public function fetchImage(id:String, costumeName:String, width:int, whenDone:Function, otherData:Object = null):URLLoader {
 		// Fetch an image asset from the server and call whenDone with the resulting ScratchCostume.
 		var c:ScratchCostume;
 		function gotCostumeData(data:ByteArray):void {
@@ -318,7 +318,10 @@ public class ProjectIO {
 				return;
 			}
 			if (ScratchCostume.isSVGData(data)) {
-				c = new ScratchCostume(costumeName, data);
+				if (otherData && otherData.centerX)
+					c = new ScratchCostume(costumeName, data, otherData.centerX, otherData.centerY, otherData.bitmapResolution);
+				else
+					c = new ScratchCostume(costumeName, data);
 				c.baseLayerMD5 = id;
 				whenDone(c);
 			} else {
@@ -332,7 +335,10 @@ public class ProjectIO {
 			app.log('ProjectIO failed to load: ' + id);
 		}
 		function imageLoaded(e:Event):void {
-			c = new ScratchCostume(costumeName, e.target.content.bitmapData);
+			if (otherData && otherData.centerX)
+				c = new ScratchCostume(costumeName, e.target.content.bitmapData, otherData.centerX, otherData.centerY, otherData.bitmapResolution);
+			else
+				c = new ScratchCostume(costumeName, e.target.content.bitmapData);
 			if (width) c.bitmapResolution = c.baseLayerBitmap.width / width;
 			c.baseLayerMD5 = id;
 			whenDone(c);

--- a/src/util/Server.as
+++ b/src/util/Server.as
@@ -86,8 +86,8 @@ public class Server implements IServer {
 		return fetchAsset('media/' + md5, whenDone);
 	}
 
-	public function getMediaLibrary(whenDone:Function):URLLoader {
-		return getAsset('mediaLibrary.json', whenDone);
+	public function getMediaLibrary(type:String, whenDone:Function):URLLoader {
+		return getAsset('libs/'+type+'Library.json', whenDone);
 	}
 
 	public function getThumbnail(md5:String, w:int, h:int, whenDone:Function):URLLoader {


### PR DESCRIPTION
Use separate files for sprites, costumes, backdrops, and sounds. This makes them load faster and the costume library is now generated from the sprite library.