### PR TITLE
#621 Adding ? At the End Of List Contains Block

### DIFF
--- a/src/Specs.as
+++ b/src/Specs.as
@@ -355,7 +355,7 @@ public class Specs {
 		["-"],
 		["item %d.listItem of %m.list",						"r", 12, "getLine:ofList:"],
 		["length of %m.list",								"r", 12, "lineCountOfList:"],
-		["%m.list contains %s",								"b", 12, "list:contains:"],
+		["%m.list contains %s?",								"b", 12, "list:contains:"],
 		["-"],
 		["show list %m.list",								" ", 12, "showList:"],
 		["hide list %m.list",								" ", 12, "hideList:"],


### PR DESCRIPTION
Adding ? at the end of <list contains> block to make it consistent with other boolean blocks

Fixes #621 

##TestCases : 

1. Make sure <list contains> block works as expected
2. Make sure the other blocks look ok 

