### PR TITLE
Remove translation metadata from translator map

### DIFF
--- a/src/translation/Translator.as
+++ b/src/translation/Translator.as
@@ -189,6 +189,7 @@ public class Translator {
 			if (mode == 'val') val += extractQuotedString(line);
 		}
 		if (mode == 'val') dict[key] = val; // recordPairIn(key, val, dict);
+		delete dict['']; // remove the empty-string metadata entry, if present.
 		return dict;
 	}
 


### PR DESCRIPTION
By convention, a PO file contains a metadata entry that uses the empty
string as its key. Our translator was translating the empty string into
this metadata. Now, that entry is removed on dictionary construction.

This fixes LLK/scratch-flash-online#129
