### PR TITLE
Removed unused methods in interface. Cleaned up and optimized stamping.

### DIFF
--- a/src/IRenderIn3D.as
+++ b/src/IRenderIn3D.as
@@ -35,10 +35,8 @@ public interface IRenderIn3D {SCRATCH::allow3d{
 	function getOtherRenderedChildren(skipObj:DisplayObject, scale:Number):BitmapData;
 	function updateRender(dispObj:DisplayObject, renderID:String = null, renderOpts:Object = null):void;
 	function updateFilters(dispObj:DisplayObject, effects:Object):void;
-	function updateGeometry(dispObj:DisplayObject):void;
 	function onStageResize(e:Event = null):void;
 	function getRender(bmd:BitmapData):void;
 	function setStatusCallback(callback:Function):void;
-	function spriteIsLarge(dispObj:DisplayObject):Boolean;
 }}
 }

--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -504,7 +504,6 @@ public class DisplayObjectContainerIn3D extends Sprite implements IRenderIn3D {S
 		var bmID:String = spriteBitmaps[dispObj];
 		var renderOpts:Object = spriteRenderOpts[dispObj];
 		var roundLoc:Boolean = (rot % 90 == 0 && dispObj.scaleX == 1.0 && dispObj.scaleY == 1.0);
-//			var forcePixelate:Boolean = pixelateAll || (renderOpts && renderOpts.bitmap && rot % 90 == 0);
 
 		var boundsX:Number = bounds.left, boundsY:Number = bounds.top;
 		var childRender:ChildRender = bitmapsByID[bmID] as ChildRender;
@@ -1145,6 +1144,8 @@ public class DisplayObjectContainerIn3D extends Sprite implements IRenderIn3D {S
 		__context.setScissorRectangle(new Rectangle(0, 0, bmd.width + 1, bmd.height + 1));
 		render(1, false);
 		__context.drawToBitmapData(bmd);
+		// TODO: Fix bright edges of renders
+//		trace('Edge pixel: 0x'+bmd.getPixel32(bmd.width - 1, bmd.height - 1).toString(16).toUpperCase());
 
 		if (changeBackBuffer) {
 			scissorRect = null;

--- a/src/render3d/SpriteStamp.as
+++ b/src/render3d/SpriteStamp.as
@@ -23,7 +23,7 @@ package render3d {
 	public class SpriteStamp extends BitmapData {
 		private var fx:Object;
 		public function SpriteStamp(width:int, height:int, fx:Object) {
-			super(width, height, true, 0x00ffffff);
+			super(width, height, true, 0);
 			effects = fx;
 		}
 

--- a/src/scratch/ScratchObj.as
+++ b/src/scratch/ScratchObj.as
@@ -257,11 +257,11 @@ public class ScratchObj extends Sprite {
 			img.transform.colorTransform = cTrans;
 		}
 		else {
-			updateEffects();
+			updateEffectsFor3D();
 		}
 	}
 
-	protected function updateEffects():void {
+	public function updateEffectsFor3D():void {
 		SCRATCH::allow3d {
 			if((parent && parent is ScratchStage) || this is ScratchStage) {
 				if(parent is ScratchStage)

--- a/src/scratch/ScratchSprite.as
+++ b/src/scratch/ScratchSprite.as
@@ -370,10 +370,10 @@ public class ScratchSprite extends ScratchObj {
 			if (Scratch.app.isIn3D) {
 				var oldGhost:Number = filterPack.getFilterSetting('ghost');
 				filterPack.setFilter('ghost', 0);
-				updateEffects();
+				updateEffectsFor3D();
 				var bm:BitmapData = Scratch.app.render3D.getRenderedChild(this, b.width * scaleX, b.height * scaleY);
 				filterPack.setFilter('ghost', oldGhost);
-				updateEffects();
+				updateEffectsFor3D();
 //	    		if(objName == 'Tank 2 down bumper ') {
 //		    		if(!testSpr.parent) {
 //			    		testBM.filters = [new GlowFilter(0xFF00FF, 0.8)];

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -424,28 +424,23 @@ public class ScratchStage extends ScratchObj {
 		}
 	}
 
+	SCRATCH::allow3d
 	public function getBitmapOfSprite(s:ScratchSprite, bounds:Rectangle, for_carry:Boolean = false):BitmapData {
 		var b:Rectangle = s.currentCostume().bitmap ? s.img.getChildAt(0).getBounds(s) : s.getVisibleBounds(s);
 		bounds.width = b.width; bounds.height = b.height; bounds.x = b.x; bounds.y = b.y;
 		if(!Scratch.app.render3D || s.width < 1 || s.height < 1) return null;
 
-		if (SCRATCH::allow3d) {
-			var ghost:Number = s.filterPack.getFilterSetting('ghost');
-			var oldBright:Number = s.filterPack.getFilterSetting('brightness');
-			s.filterPack.setFilter('ghost', 0);
-			s.filterPack.setFilter('brightness', 0);
-			s.applyFilters();
-			var bmd:BitmapData = Scratch.app.render3D.getRenderedChild(s, b.width * s.scaleX, b.height * s.scaleY, for_carry);
-			s.filterPack.setFilter('ghost', ghost);
-			s.filterPack.setFilter('brightness', oldBright);
-			s.applyFilters();
+		var ghost:Number = s.filterPack.getFilterSetting('ghost');
+		var oldBright:Number = s.filterPack.getFilterSetting('brightness');
+		s.filterPack.setFilter('ghost', 0);
+		s.filterPack.setFilter('brightness', 0);
+		s.updateEffectsFor3D();
+		var bmd:BitmapData = Scratch.app.render3D.getRenderedChild(s, b.width * s.scaleX, b.height * s.scaleY, for_carry);
+		s.filterPack.setFilter('ghost', ghost);
+		s.filterPack.setFilter('brightness', oldBright);
+		s.updateEffectsFor3D();
 
-			return bmd;
-		}
-		else {
-			// We should never get here due to the test for Scratch.app.render3D above
-			return null;
-		}
+		return bmd;
 	}
 
 	public function setVideoState(newState:String):void {


### PR DESCRIPTION
This is a continuation of the fix made for https://github.com/LLK/scratch-flash/issues/685.