### PR TITLE
Fix integer processing

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -457,7 +457,7 @@ public class Block extends Sprite {
 		for (i = 0; i < labelsAndArgs.length; i++) {
 			item = labelsAndArgs[i];
 			item.y = indentTop + ((maxH - item.height) / 2) + vOffset;
-			if ((item is BlockArg) && (!BlockArg(item).isNumber)) item.y += 1;
+			if ((item is BlockArg) && (!BlockArg(item).numberType)) item.y += 1;
 		}
 
 		if ([' ', '', 'o'].indexOf(type) >= 0) x = Math.max(x, minCommandWidth); // minimum width for command blocks
@@ -986,10 +986,10 @@ public class Block extends Sprite {
 			space = true;
 			var ba:BlockArg, b:Block, tf:TextField;
 			if ((ba = x as BlockArg)) {
-				s += ba.isNumber ? "(" : "[";
+				s += ba.numberType ? "(" : "[";
 				s += ba.argValue;
 				if (!ba.isEditable) s += " v";
-				s += ba.isNumber ? ")" : "]";
+				s += ba.numberType ? ")" : "]";
 			} else if ((b = x as Block)) {
 				s += b.getSummary();
 			} else if ((tf = x as TextField)) {

--- a/src/blocks/BlockArg.as
+++ b/src/blocks/BlockArg.as
@@ -160,12 +160,6 @@ public class BlockArg extends Sprite {
 					field.text = Translator.map(value);
 				}
 			}
-
-//			if (!label && (value is Number) && ((value - epsilon) is int)) {
-//				// Append '.0' to numeric values that are exactly epsilon
-//				// greater than an integer. See comment in textChanged().
-//				field.text = (value - epsilon) + '.0';
-//			}
 			textChanged(null);
 			argValue = value; // set argValue after textChanged()
 			return;

--- a/src/blocks/BlockArg.as
+++ b/src/blocks/BlockArg.as
@@ -224,8 +224,8 @@ public class BlockArg extends Sprite {
 			if (!isNaN(n)) {
 				argValue = n;
 
-				// For number arguments that are integers AND contain a decimal point, mark them as an INTEGER (used by pick random)
-				numberType = (field.text.indexOf('.') >= 0 && n is int) ? NT_INT : NT_FLOAT;
+				// For number arguments that are integers AND do NOT contain a decimal point, mark them as an INTEGER (used by pick random)
+				numberType = (field.text.indexOf('.') == -1 && n is int) ? NT_INT : NT_FLOAT;
 			}
 			else
 				numberType = NT_FLOAT;

--- a/src/blocks/BlockArg.as
+++ b/src/blocks/BlockArg.as
@@ -47,11 +47,14 @@ package blocks {
 public class BlockArg extends Sprite {
 
 	public static const epsilon:Number = 1 / 4294967296;
+	public static const NT_NOT_NUMBER:uint = 0;
+	public static const NT_FLOAT:uint = 1;
+	public static const NT_INT:uint = 2;
 
 	public var type:String;
 	public var base:BlockShape;
 	public var argValue:* = '';
-	public var isNumber:Boolean;
+	public var numberType:uint = NT_NOT_NUMBER;
 	public var isEditable:Boolean;
 	public var field:TextField;
 	public var menuName:String;
@@ -70,7 +73,7 @@ public class BlockArg extends Sprite {
 		this.type = type;
 
 		if (color == -1) { // copy for clone; omit graphics
-			if ((type == 'd') || (type == 'n')) isNumber = true;
+			if ((type == 'd') || (type == 'n')) numberType = NT_FLOAT;
 			return;
 		}
 		var c:int = Color.scaleBrightness(color, 0.92);
@@ -83,7 +86,7 @@ public class BlockArg extends Sprite {
 			addEventListener(MouseEvent.MOUSE_DOWN, invokeMenu);
 		} else if (type == 'd') {
 			base = new BlockShape(BlockShape.NumberShape, c);
-			isNumber = true;
+			numberType = NT_FLOAT;
 			this.menuName = menuName;
 			addEventListener(MouseEvent.MOUSE_DOWN, invokeMenu);
 		} else if (type == 'm') {
@@ -92,7 +95,7 @@ public class BlockArg extends Sprite {
 			addEventListener(MouseEvent.MOUSE_DOWN, invokeMenu);
 		} else if (type == 'n') {
 			base = new BlockShape(BlockShape.NumberShape, c);
-			isNumber = true;
+			numberType = NT_FLOAT;
 			argValue = 0;
 		} else if (type == 's') {
 			base = new BlockShape(BlockShape.RectShape, c);
@@ -124,12 +127,12 @@ public class BlockArg extends Sprite {
 			addChild(menuIcon);
 		}
 
-		if (editable || isNumber || (type == 'm')) { // add a string field
+		if (editable || numberType || (type == 'm')) { // add a string field
 			field = makeTextField();
 			if ((type == 'm') && !editable) field.textColor = 0xFFFFFF;
 			else base.setWidthAndTopHeight(30, Block.argTextFormat.size + 5); // 14 for normal arg font
-			field.text = isNumber ? '10' : '';
-			if (isNumber) field.restrict = '0-9e.\\-'; // restrict to numeric characters
+			field.text = numberType ? '10' : '';
+			if (numberType) field.restrict = '0-9e.\\-'; // restrict to numeric characters
 			if (editable) {
 				base.setColor(0xFFFFFF); // if editable, set color to white
 				isEditable = true;
@@ -158,11 +161,11 @@ public class BlockArg extends Sprite {
 				}
 			}
 
-			if (!label && (value is Number) && ((value - epsilon) is int)) {
-				// Append '.0' to numeric values that are exactly epsilon
-				// greater than an integer. See comment in textChanged().
-				field.text = (value - epsilon) + '.0';
-			}
+//			if (!label && (value is Number) && ((value - epsilon) is int)) {
+//				// Append '.0' to numeric values that are exactly epsilon
+//				// greater than an integer. See comment in textChanged().
+//				field.text = (value - epsilon) + '.0';
+//			}
 			textChanged(null);
 			argValue = value; // set argValue after textChanged()
 			return;
@@ -210,26 +213,20 @@ public class BlockArg extends Sprite {
 
 	private function argTextInsets(type:String = ''):Array {
 		if (type == 'b') return [5, 0];
-		return isNumber ? [3, 0] : [2, -1];
+		return numberType ? [3, 0] : [2, -1];
 	}
 
 	private function textChanged(evt:*):void {
 		argValue = field.text;
-		if (isNumber) {
+		if (numberType) {
 			// optimization: coerce to a number if possible
 			var n:Number = Number(argValue);
 			if (!isNaN(n)) {
 				argValue = n;
-				if ((field.text.indexOf('.') >= 0) && (argValue is int)) {
-					// if text includes a decimal point, make value a float as a signal to
-					// primitives (e.g. random) to use real numbers rather than integers.
-					// Note: Flash does not appear to distinguish between a floating point
-					// value with no fractional part and an int of that value. We mark
-					// arguments like 1.0 by adding a tiny epsilon to force them to be a
-					// floating point number. Certain primitives, such as random, use
-					// this to decide whether to work in integers or real numbers.
-					argValue += epsilon;
-				}
+
+				// For number arguments that are integers AND contain a decimal point, mark them as an INTEGER (used by pick random)
+				if (numberType)
+					numberType = (field.text.indexOf('.') >= 0 && n is int) ? NT_INT : NT_FLOAT;
 			}
 		}
 		// fix layout:

--- a/src/blocks/BlockArg.as
+++ b/src/blocks/BlockArg.as
@@ -225,9 +225,10 @@ public class BlockArg extends Sprite {
 				argValue = n;
 
 				// For number arguments that are integers AND contain a decimal point, mark them as an INTEGER (used by pick random)
-				if (numberType)
-					numberType = (field.text.indexOf('.') >= 0 && n is int) ? NT_INT : NT_FLOAT;
+				numberType = (field.text.indexOf('.') >= 0 && n is int) ? NT_INT : NT_FLOAT;
 			}
+			else
+				numberType = NT_FLOAT;
 		}
 		// fix layout:
 		var padding:int = (type == 'n') ? 3 : 0;

--- a/src/primitives/Primitives.as
+++ b/src/primitives/Primitives.as
@@ -97,7 +97,7 @@ public class Primitives {
 		var hi:Number = (n1 <= n2) ? n2 : n1;
 		if (low == hi) return low;
 		// if both low and hi are ints, truncate the result to an int
-		if ((int(low) == low) && (int(hi) == hi)) {
+		if (b.args[0].numberType == BlockArg.NT_INT || b.args[1].numberType == BlockArg.NT_INT) {
 			return low + int(Math.random() * ((hi + 1) - low));
 		}
 		return (Math.random() * (hi - low)) + low;

--- a/src/primitives/Primitives.as
+++ b/src/primitives/Primitives.as
@@ -96,10 +96,11 @@ public class Primitives {
 		var low:Number = (n1 <= n2) ? n1 : n2;
 		var hi:Number = (n1 <= n2) ? n2 : n1;
 		if (low == hi) return low;
+
 		// if both low and hi are ints, truncate the result to an int
-		if (b.args[0].numberType == BlockArg.NT_INT && b.args[1].numberType == BlockArg.NT_INT) {
+		if (b.args[0].numberType == BlockArg.NT_INT && b.args[1].numberType == BlockArg.NT_INT)
 			return low + int(Math.random() * ((hi + 1) - low));
-		}
+
 		return (Math.random() * (hi - low)) + low;
 	}
 

--- a/src/primitives/Primitives.as
+++ b/src/primitives/Primitives.as
@@ -97,7 +97,7 @@ public class Primitives {
 		var hi:Number = (n1 <= n2) ? n2 : n1;
 		if (low == hi) return low;
 		// if both low and hi are ints, truncate the result to an int
-		if (b.args[0].numberType == BlockArg.NT_INT || b.args[1].numberType == BlockArg.NT_INT) {
+		if (b.args[0].numberType == BlockArg.NT_INT && b.args[1].numberType == BlockArg.NT_INT) {
 			return low + int(Math.random() * ((hi + 1) - low));
 		}
 		return (Math.random() * (hi - low)) + low;


### PR DESCRIPTION
This removes the code that added epsilon (1 / 4294967296) to integer block arguments that contained a decimal point. This caused issues with 'ceiling' and comparing values (0.0 != 0).
There were ways to implement this that would not perform well or would increase memory usage. I think I found a good way to fix this while maintaining performance and memory usage.
Fixes #582