### PR TITLE
Extension save load fixes

### DIFF
--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -206,9 +206,7 @@ public class ExtensionManager {
 		return ext;
 	}
 			
-			
 	public function loadExtensionData(ext:ScratchExtension, extObj:Object):void {		
-		
 		extensionDict[extObj.extensionName] = ext;
 		ext.port = extObj.extensionPort;
 		ext.blockSpecs = extObj.blockSpecs;

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -75,9 +75,8 @@ public class ExtensionManager {
 	public function specForCmd(op:String):Array {
 		// Return a command spec array for the given operation or null.
 		for each (var ext:ScratchExtension in extensionDict) {
-			var prefix:String = ext.useScratchPrimitives ? '' : (ext.name + '.');
 			for each (var spec:Array in ext.blockSpecs) {
-				if ((spec.length > 2) && ((prefix + spec[2]) == op)) {
+				if ((spec.length > 2) && ((ext.name + '.' + spec[2]) == op)) {
 					return [spec[1], spec[0], Specs.extensionsCategory, op, spec.slice(3)];
 				}
 			}
@@ -101,8 +100,11 @@ public class ExtensionManager {
 				}
 				else {
 					app.externalCall('ScratchExtensions.unregister', null, extName);
-					delete extensionDict[extName];
+					if(!ext.isInternal) delete extensionDict[extName];
 				}
+			}
+			else {
+				 if(!flag) delete extensionDict[extName];
 			}
 		}
 	}
@@ -139,8 +141,11 @@ public class ExtensionManager {
 			descriptor.extensionName = ext.name;
 			descriptor.blockSpecs = ext.blockSpecs;
 			descriptor.menus = ext.menus;
+			if(ext.tags) descriptor.tags = ext.tags;
+			if(ext.thumbnailMD5) descriptor.thumbnailMD5 = ext.thumbnailMD5;			
+			if(ext.url) descriptor.url = ext.url;
 			if(ext.port) descriptor.extensionPort = ext.port;
-			else if(ext.javascriptURL) descriptor.javascriptURL = ext.javascriptURL;
+			if(ext.javascriptURL) descriptor.javascriptURL = ext.javascriptURL;
 			result.push(descriptor);
 		}
 		return result;
@@ -191,27 +196,48 @@ public class ExtensionManager {
 		var ext:ScratchExtension = extensionDict[extObj.extensionName];
 		if(!ext)
 			ext = new ScratchExtension(extObj.extensionName, extObj.extensionPort);
+			
+		loadExtensionData(ext, extObj);	
+		//not within loadExtensionData() as not safe to load from a saved file
+		if (extObj.host) ext.host = extObj.host; // non-local host allowed but not saved in project
+		
+		Scratch.app.translationChanged();
+		Scratch.app.updatePalette();
+		return ext;
+	}
+			
+			
+	public function loadExtensionData(ext:ScratchExtension, extObj:Object):void {		
+		
+		extensionDict[extObj.extensionName] = ext;
 		ext.port = extObj.extensionPort;
 		ext.blockSpecs = extObj.blockSpecs;
-		if (app.isOffline && (ext.port == 0)) {
-			// Fix up block specs to force reporters to be treated as requesters.
-			// This is because the offline JS interface doesn't support returning values directly.
-			for each(var spec:Object in ext.blockSpecs) {
-				if(spec[0] == 'r') {
-					// 'r' is reporter, 'R' is requester, and 'rR' is a reporter forced to act as a requester.
-					spec[0] = 'rR';
-				}
+		
+		// Fix up block specs to force reporters to be treated as requesters.
+		// This is because the offline JS interface doesn't support returning values directly.
+		// 'r' is reporter, 'R' is requester, and 'rR' is a reporter forced to act as a requester.
+		// A saved .sb2 file may contain either 'r' or 'rR', so fix in both directions
+		for each(var spec:Object in ext.blockSpecs) {
+			if (app.isOffline && (ext.port == 0)) {
+				if (spec[0] == 'r') spec[0] = 'rR';
+			} else {
+				if(spec[0] == 'rR') spec[0] = 'r';		
 			}
 		}
 		if(extObj.url) ext.url = extObj.url;
+		if(extObj.tags) ext.tags = extObj.tags;
+		if(extObj.thumbnailMD5) ext.thumbnailMD5 = extObj.thumbnailMD5;	
 		ext.showBlocks = true;
 		ext.menus = extObj.menus;
-		ext.javascriptURL = extObj.javascriptURL;
-		if (extObj.host) ext.host = extObj.host; // non-local host allowed but not saved in project
-		extensionDict[extObj.extensionName] = ext;
-		Scratch.app.translationChanged();
-		Scratch.app.updatePalette();
-
+		ext.isInternal = false; // For now?
+						
+		if(extObj.javascriptURL) {
+			ext.javascriptURL = extObj.javascriptURL;
+			ext.showBlocks = false;
+			//if(extObj.id) ext.id = extObj.id;
+			setEnabled(extObj.extensionName, true);
+		}
+						
 		// Update the indicator
 		for (var i:int = 0; i < app.palette.numChildren; i++) {
 			var indicator:IndicatorLight = app.palette.getChildAt(i) as IndicatorLight;
@@ -220,8 +246,6 @@ public class ExtensionManager {
 				break;
 			}
 		}
-
-		return ext;
 	}
 
 	public function loadSavedExtensions(savedExtensions:Array):void {
@@ -240,18 +264,9 @@ public class ExtensionManager {
 			}
 
 			var ext:ScratchExtension = new ScratchExtension(extObj.extensionName, extObj.extensionPort || 0);
-			extensionDict[extObj.extensionName] = ext;
-			ext.blockSpecs = extObj.blockSpecs;
-			ext.showBlocks = true;
-			ext.isInternal = false; // For now?
-			ext.menus = extObj.menus;
-			if(extObj.javascriptURL) {
-				ext.javascriptURL = extObj.javascriptURL;
-				ext.showBlocks = false;
-				if(extObj.id) ext.id = extObj.id;
-				setEnabled(extObj.extensionName, true);
-			}
+			loadExtensionData(ext, extObj);		
 		}
+		Scratch.app.translationChanged();
 		Scratch.app.updatePalette();
 	}
 

--- a/src/extensions/ScratchExtension.as
+++ b/src/extensions/ScratchExtension.as
@@ -44,10 +44,10 @@ public class ScratchExtension {
 	public var name:String = '';
 	public var host:String = '127.0.0.1'; // most extensions run on the local host
 	public var port:int = 0;
-	public var id:uint = 0;
+	//public var id:uint = 0;
 	public var blockSpecs:Array = [];
 	public var isInternal:Boolean;
-	public var useScratchPrimitives:Boolean; // true for extensions built into Scratch (WeDo, PicoBoard) that have custom primitives
+	//public var useScratchPrimitives:Boolean; // true for extensions built into Scratch (WeDo, PicoBoard) that have custom primitives
 	public var showBlocks:Boolean;
 	public var menus:Object = {};
 	public var thumbnailMD5:String = ''; // md5 has for extension image shown in extension library

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -362,6 +362,9 @@ public class PaletteBuilder {
 				else if(ext.url.indexOf('http') === 0) navigateToURL(new URLRequest(ext.url));
 				else DialogBox.notify('Extensions', 'Unable to load about page: the URL given for extension "' + ext.name + '" is not formatted correctly.');
 			}
+			else {
+				DialogBox.notify('Extensions', 'Unable to load about page: the URL given for extension "' + ext.name + '" is not found.');
+			}
 		}
 		function hideExtension():void {
 			app.extensionManager.setEnabled(ext.name, false);
@@ -392,7 +395,7 @@ public class PaletteBuilder {
 		var indicator:IndicatorLight = new IndicatorLight(ext);
 		indicator.addEventListener(MouseEvent.CLICK, function(e:Event):void {Scratch.app.showTip('extensions');}, false, 0, true);
 		app.extensionManager.updateIndicator(indicator, ext);
-		indicator.x = pwidth - 30;
+		indicator.x = pwidth - 40;
 		indicator.y = nextY + 2;
 		app.palette.addChild(indicator);
 
@@ -401,18 +404,18 @@ public class PaletteBuilder {
 
 	protected function addLineForExtensionTitle(titleButton:IconButton, ext:ScratchExtension):void {
 		var x:int = titleButton.width + 12;
-		addLine(x, nextY + 9, pwidth - x - 38);
+		addLine(x, nextY + 9, pwidth - x - 48);
 	}
 
 	private function addBlocksForExtension(ext:ScratchExtension):void {
 		var blockColor:int = Specs.extensionsColor;
-		var opPrefix:String = ext.useScratchPrimitives ? '' : ext.name + '.';
 		for each (var spec:Array in ext.blockSpecs) {
 			if (spec.length >= 3) {
-				var op:String = opPrefix + spec[2];
+				var op:String = ext.name + '.' + spec[2];
 				var defaultArgs:Array = spec.slice(3);
 				var block:Block = new Block(spec[1], spec[0], blockColor, op, defaultArgs);
-				var showCheckbox:Boolean = (spec[0] == 'r' && defaultArgs.length == 0);
+				var isItr:Boolean = (spec[0] == 'r' || spec[0] == 'rR');
+				var showCheckbox:Boolean = (isItr && defaultArgs.length == 0);
 				if (showCheckbox) addReporterCheckbox(block);
 				addItem(block, showCheckbox);
 			} else {


### PR DESCRIPTION
Fixes for #500, #514, #557 and a few other similar extension issues

1) Fixes #500
Upon new project wedo/picoboard are preloaded (so their icons are available for the Extension Library).
Clicking the icon when selecting the extension simply sets .showBlocks to true. 

However when the 'remove extension blocks' menu was clicked their entry was deleted completely from extensionDict.
This means that the process of 
Load (setEnabled(true)) - Remove (setEnabled(false)) - Load (setEnabled(true)) 
failed on the second load, as the extensionDict entry no longer existed (even though the icon still shown in Library).

Fixed by checking for isInternal before delete

2) 
http extensions were previously never deleted upon 'Remove' menu

3) Fixes #514
ext.url etc. were not saved in extensionsToSave

4) 
ext.port is always present (even if 0), so removed 'else' for 'javascriptURL' in extensionsToSave

5) Fixes #557, #514
loadRawData and loadExtensionData now share code to correct issues like .url missing upon load of an .sb2 file

6) 
[rR] v [r] fix is now done in both directions, as a saved .sb2 file could actually contain either

7)
Removed unused (historical)
ScratchExtension.useScratchPrimitives
ScratchExtension.id

8) Moved extension indicator LED left by 10 pixels so no longer partially obscured by vertical scrollbar (when 2 or more extensions used)

9) Re-instated checkbox for [rR] reporter blocks in the offline version

@sclements for  is 9) ok for [rR] variant?