### PR TITLE
Aborting block drag operations by pressing ESC

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -154,7 +154,11 @@ public class Scratch extends Sprite {
 		stage.addEventListener(MouseEvent.MOUSE_UP, gh.mouseUp);
 		stage.addEventListener(MouseEvent.MOUSE_WHEEL, gh.mouseWheel);
 		stage.addEventListener('rightClick', gh.rightMouseClick);
-		stage.addEventListener(KeyboardEvent.KEY_DOWN, runtime.keyDown);
+		stage.addEventListener(KeyboardEvent.KEY_DOWN, function(evt:KeyboardEvent): void {
+			if (!evt.shiftKey && evt.charCode == 27) gh.escKeyDown();
+			else runtime.keyDown(evt);
+		});
+
 		stage.addEventListener(KeyboardEvent.KEY_UP, runtime.keyUp);
 		stage.addEventListener(KeyboardEvent.KEY_DOWN, keyDown); // to handle escape key
 		stage.addEventListener(Event.ENTER_FRAME, step);

--- a/src/util/GestureHandler.as
+++ b/src/util/GestureHandler.as
@@ -48,6 +48,7 @@
 
 package util {
 	import flash.display.*;
+	import flash.events.KeyboardEvent;
 	import flash.events.MouseEvent;
 	import flash.filters.*;
 	import flash.geom.*;
@@ -332,6 +333,15 @@ public class GestureHandler {
 
 	public function mouseWheel(evt:MouseEvent):void {
 		hideBubble();
+	}
+
+	public function escKeyDown():void {
+		if (carriedObj != null && carriedObj is Block) {
+			carriedObj.stopDrag();
+			removeDropShadowFrom(carriedObj);
+			Block(carriedObj).restoreOriginalState();
+			carriedObj = null;
+		}
 	}
 
 	private function findMouseTarget(evt:MouseEvent, target:*):DisplayObject {


### PR DESCRIPTION
This change will add the function of aborting a drag operation by pressing ESC. That will restore the position/insertion of the block to the place it were when the drag operation was initiated.