### PR TITLE
Rename "presentation mode" to "full screen mode".

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -627,8 +627,8 @@ public class Scratch extends Sprite {
 
 	protected var wasEditing:Boolean;
 
-	public function setPresentationMode(enterPresentation:Boolean):void {
-		if (enterPresentation) {
+	public function setFullScreenMode(enterFullScreen:Boolean):void {
+		if (enterFullScreen) {
 			wasEditing = editMode;
 			if (wasEditing) {
 				setEditMode(false);
@@ -641,7 +641,7 @@ public class Scratch extends Sprite {
 			}
 		}
 		if (isOffline) {
-			stage.displayState = enterPresentation ? StageDisplayState.FULL_SCREEN_INTERACTIVE : StageDisplayState.NORMAL;
+			stage.displayState = enterFullScreen ? StageDisplayState.FULL_SCREEN_INTERACTIVE : StageDisplayState.NORMAL;
 		}
 		for each (var o:ScratchObj in stagePane.allObjects()) o.applyFilters();
 
@@ -657,10 +657,14 @@ public class Scratch extends Sprite {
 		if (!evt.shiftKey && evt.charCode == 27) {
 			gh.escKeyDown();
 		}
-		// Escape exists presentation mode.
-		else if ((evt.charCode == 27) && stagePart.isInPresentationMode()) {
-			setPresentationMode(false);
-			stagePart.exitPresentationMode();
+		// Escape exists full screen mode.
+		if ((evt.charCode == 27) && stagePart.isInFullScreenMode()) {
+			setFullScreenMode(false);
+			stagePart.exitFullScreenMode();
+
+
+
+
 		}
 		// Handle enter key
 //		else if(evt.keyCode == 13 && !stage.focus) {

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -371,7 +371,7 @@ public class ScratchStage extends ScratchObj {
 		// NOTE: The following code supports the scrolling backgrounds
 		// feature, which was explored but removed before launch.
 		// This prototype implementation renders SVG backdrops to a bitmap
-		// (to allow wrapping) but that causes pixelation in presentation mode.
+		// (to allow wrapping) but that causes pixelation in full screen mode.
 		// If the scrolling backgrounds feature is ever resurrected this code
 		// is a good starting point but the pixelation issue should be fixed.
 		clearCachedBitmap();

--- a/src/ui/parts/StagePart.as
+++ b/src/ui/parts/StagePart.as
@@ -132,9 +132,9 @@ public class StagePart extends UIPart {
 
 	public function projectName():String { return projectTitle.contents() }
 	public function setProjectName(s:String):void { projectTitle.setContents(s) }
-	public function isInPresentationMode():Boolean { return fullscreenButton.visible && fullscreenButton.isOn() }
+	public function isInFullScreenMode():Boolean { return fullscreenButton.visible && fullscreenButton.isOn() }
 
-	public function exitPresentationMode():void {
+	public function exitFullScreenMode():void {
 		fullscreenButton.setOn(false);
 		drawOutline();
 		refresh();
@@ -435,7 +435,7 @@ public class StagePart extends UIPart {
 
 	private function addFullScreenButton():void {
 		function toggleFullscreen(b:IconButton):void {
-			app.setPresentationMode(b.isOn());
+			app.setFullScreenMode(b.isOn());
 			drawOutline();
 		}
 		fullscreenButton = new IconButton(toggleFullscreen, 'fullscreen');

--- a/src/util/GestureHandler.as
+++ b/src/util/GestureHandler.as
@@ -221,7 +221,7 @@ public class GestureHandler {
 	}
 
 	private function doClickImmediately():Boolean {
-		// Answer true when clicking on the stage or a locked sprite in play (presentation) mode.
+		// Answer true when clicking on the stage or a locked sprite in play (full screen) mode.
 		if (app.editMode) return false;
 		if (mouseTarget is ScratchStage) return true;
 		return (mouseTarget is ScratchSprite) && !ScratchSprite(mouseTarget).isDraggable;
@@ -429,8 +429,8 @@ public class GestureHandler {
 		if (!('objToGrab' in mouseTarget)) return;
 		if (!app.editMode) {
 			if (app.loadInProgress) return;
-			if ((mouseTarget is ScratchSprite) && !ScratchSprite(mouseTarget).isDraggable) return; // don't drag locked sprites in presentation mode
-			if ((mouseTarget is Watcher) || (mouseTarget is ListWatcher)) return; // don't drag watchers in presentation mode
+			if ((mouseTarget is ScratchSprite) && !ScratchSprite(mouseTarget).isDraggable) return; // don't drag locked sprites in fullscreen mode
+			if ((mouseTarget is Watcher) || (mouseTarget is ListWatcher)) return; // don't drag watchers in fullscreen mode
 		}
 		grab(mouseTarget, evt);
 		gesture = 'drag';


### PR DESCRIPTION
The reason is that the code names this mode in two different ways without an apparent reason. This change requires translation of the string "can drag in fullscreen:" and removes the need of translating the string "can drag in player:".
