### PR TITLE
Fixing issue 727

### DIFF
--- a/src/uiwidgets/ScriptsPane.as
+++ b/src/uiwidgets/ScriptsPane.as
@@ -139,11 +139,29 @@ public class ScriptsPane extends ScrollFrameContents {
 	}
 
 	public function updateFeedbackFor(b:Block):void {
-		nearestTarget = nearestTargetForBlockIn(b, possibleTargets);
-		if (b.base.canHaveSubstack1() && !b.subStack1) {
-			var o:Block = null;
-			if (nearestTarget) {
-				t = nearestTarget[1];
+		if (mouseX + x >= 0) {
+			nearestTarget = nearestTargetForBlockIn(b, possibleTargets);
+			if (nearestTarget != null) {
+				updateFeedbackShape();
+			} else {
+				hideFeedbackShape();
+			}
+			if (b.base.canHaveSubstack1() && !b.subStack1) {
+				updateHeight();
+			}
+		}
+		else {
+			nearestTarget = null;
+			hideFeedbackShape();
+		}
+
+		fixCommentLayout();
+
+		function updateHeight(): void {
+			var h:int = BlockShape.EmptySubstackH;
+			if (nearestTarget != null) {
+				var t:* = nearestTarget[1];
+				var o:Block = null;
 				switch (nearestTarget[2]) {
 					case INSERT_NORMAL:
 						o = t.nextBlock;
@@ -158,17 +176,17 @@ public class ScriptsPane extends ScrollFrameContents {
 						o = t.subStack2;
 						break;
 				}
-			}
-			var h:int = BlockShape.EmptySubstackH;
-			if (o) {
-				h = o.height;
-				if (!o.bottomBlock().isTerminal) h -= BlockShape.NotchDepth;
+				if (o) {
+					h = o.height;
+					if (!o.bottomBlock().isTerminal) h -= BlockShape.NotchDepth;
+				}
 			}
 			b.previewSubstack1Height(h);
 		}
-		if (nearestTarget != null) {
-			var localP:Point = globalToLocal(nearestTarget[0]);
+
+		function updateFeedbackShape() : void {
 			var t:* = nearestTarget[1];
+			var localP:Point = globalToLocal(nearestTarget[0]);
 			feedbackShape.x = localP.x;
 			feedbackShape.y = localP.y;
 			feedbackShape.visible = true;
@@ -181,10 +199,7 @@ public class ScriptsPane extends ScrollFrameContents {
 				var isInsertion:Boolean = (insertionType != INSERT_ABOVE) && (insertionType != INSERT_WRAP);
 				feedbackShape.copyFeedbackShapeFrom(b, false, isInsertion, wrapH);
 			}
-		} else {
-			hideFeedbackShape();
 		}
-		fixCommentLayout();
 	}
 
 	public function allStacks():Array {

--- a/src/uiwidgets/ScriptsPane.as
+++ b/src/uiwidgets/ScriptsPane.as
@@ -139,23 +139,6 @@ public class ScriptsPane extends ScrollFrameContents {
 	}
 
 	public function updateFeedbackFor(b:Block):void {
-		if (mouseX + x >= 0) {
-			nearestTarget = nearestTargetForBlockIn(b, possibleTargets);
-			if (nearestTarget != null) {
-				updateFeedbackShape();
-			} else {
-				hideFeedbackShape();
-			}
-			if (b.base.canHaveSubstack1() && !b.subStack1) {
-				updateHeight();
-			}
-		}
-		else {
-			nearestTarget = null;
-			hideFeedbackShape();
-		}
-
-		fixCommentLayout();
 
 		function updateHeight(): void {
 			var h:int = BlockShape.EmptySubstackH;
@@ -200,6 +183,24 @@ public class ScriptsPane extends ScrollFrameContents {
 				feedbackShape.copyFeedbackShapeFrom(b, false, isInsertion, wrapH);
 			}
 		}
+
+		if (mouseX + x >= 0) {
+			nearestTarget = nearestTargetForBlockIn(b, possibleTargets);
+			if (nearestTarget != null) {
+				updateFeedbackShape();
+			} else {
+				hideFeedbackShape();
+			}
+			if (b.base.canHaveSubstack1() && !b.subStack1) {
+				updateHeight();
+			}
+		}
+		else {
+			nearestTarget = null;
+			hideFeedbackShape();
+		}
+
+		fixCommentLayout();
 	}
 
 	public function allStacks():Array {


### PR DESCRIPTION
When dragging a block from the scripts palette to the scripts panel, insertion/wrapping previews will only occur when the mouse is inside the scripts panel.

This issue is reported in https://github.com/LLK/scratch-flash/issues/727