### PR TITLE
Alternative fix of issue 730, removing alpha component from pen color

### DIFF
--- a/src/primitives/MotionAndPenPrims.as
+++ b/src/primitives/MotionAndPenPrims.as
@@ -253,7 +253,7 @@ public class MotionAndPenPrims {
 
 	private function primSetPenColor(b:Block):void {
 		var s:ScratchSprite = interp.targetSprite();
-		if (s != null) s.setPenColor(interp.numarg(b, 0));
+		if (s != null) s.setPenColor(0xFFFFFF & interp.numarg(b, 0));
 	}
 
 	private function primSetPenHue(b:Block):void {


### PR DESCRIPTION
This change just removes the alpha component when setting pen color.

Would fix the nconsistency issued in https://github.com/LLK/scratch-flash/issues/730