### PR TITLE
Fix null stage refs in paint editor by adding a static var for the stage

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -46,6 +46,8 @@ import render3d.DisplayObjectContainerIn3D;
 
 import scratch.*;
 
+import svgeditor.tools.SVGTool;
+
 import translation.*;
 
 import ui.*;
@@ -115,6 +117,7 @@ public class Scratch extends Sprite {
 	public const tipsBarClosedWidth:int = 17;
 
 	public function Scratch() {
+		SVGTool.setStage(stage);
 		loaderInfo.uncaughtErrorEvents.addEventListener(UncaughtErrorEvent.UNCAUGHT_ERROR, uncaughtErrorHandler);
 		app = this;
 

--- a/src/svgeditor/tools/BitmapPencilTool.as
+++ b/src/svgeditor/tools/BitmapPencilTool.as
@@ -51,17 +51,17 @@ public final class BitmapPencilTool extends SVGTool {
 
 	override protected function init():void {
 		super.init();
-		editor.stage.addEventListener(MouseEvent.MOUSE_DOWN, mouseDown, false, 0, true);
-		editor.stage.addEventListener(MouseEvent.MOUSE_MOVE, mouseMove, false, 0, true);
-		editor.stage.addEventListener(MouseEvent.MOUSE_UP, mouseUp, false, 0, true);
+		STAGE.addEventListener(MouseEvent.MOUSE_DOWN, mouseDown, false, 0, true);
+		STAGE.addEventListener(MouseEvent.MOUSE_MOVE, mouseMove, false, 0, true);
+		STAGE.addEventListener(MouseEvent.MOUSE_UP, mouseUp, false, 0, true);
 		editor.getToolsLayer().mouseEnabled = false;
 		updateProperties();
 	}
 
 	override protected function shutdown():void {
-		editor.stage.removeEventListener(MouseEvent.MOUSE_DOWN, mouseDown);
-		editor.stage.removeEventListener(MouseEvent.MOUSE_MOVE, mouseMove);
-		editor.stage.removeEventListener(MouseEvent.MOUSE_UP, mouseUp);
+		STAGE.removeEventListener(MouseEvent.MOUSE_DOWN, mouseDown);
+		STAGE.removeEventListener(MouseEvent.MOUSE_MOVE, mouseMove);
+		STAGE.removeEventListener(MouseEvent.MOUSE_UP, mouseUp);
 		editor.getToolsLayer().mouseEnabled = true;
 		removeFeedback();
 		super.shutdown();

--- a/src/svgeditor/tools/EraserTool.as
+++ b/src/svgeditor/tools/EraserTool.as
@@ -84,26 +84,26 @@ package svgeditor.tools
 		override protected function init():void {
 			super.init();
 			editor.getWorkArea().addEventListener(MouseEvent.MOUSE_DOWN, mouseDown, false, 0, true);
-			stage.addChild(eraserShape);
+			STAGE.addChild(eraserShape);
 			updateIcon();
 		}
 
 		override protected function shutdown():void {
 			editor.getWorkArea().removeEventListener(MouseEvent.MOUSE_DOWN, mouseDown);
 			super.shutdown();
-			stage.removeChild(eraserShape);
+			STAGE.removeChild(eraserShape);
 		}
 
 		private function mouseDown(e:MouseEvent):void {
 			editor.getWorkArea().addEventListener(MouseEvent.MOUSE_MOVE, erase, false, 0, true);
-			editor.stage.addEventListener(MouseEvent.MOUSE_UP, mouseUp, false, 0, true);
+			STAGE.addEventListener(MouseEvent.MOUSE_UP, mouseUp, false, 0, true);
 			eraserWidth = editor.getShapeProps().eraserWidth;
 			erase();
 		}
 
 		private function mouseUp(e:MouseEvent):void {
 			editor.getWorkArea().removeEventListener(MouseEvent.MOUSE_MOVE, erase);
-			editor.stage.removeEventListener(MouseEvent.MOUSE_UP, mouseUp);
+			STAGE.removeEventListener(MouseEvent.MOUSE_UP, mouseUp);
 			erase();
 			lastPos = null;
 			dispatchEvent(new Event(Event.CHANGE));

--- a/src/svgeditor/tools/EyeDropperTool.as
+++ b/src/svgeditor/tools/EyeDropperTool.as
@@ -57,8 +57,8 @@ package svgeditor.tools
 			currentEvent = event;
 			grabColor();
 
-			editor.stage.addEventListener(MouseEvent.MOUSE_MOVE, mouseMove, false, 0, true);
-			editor.stage.addEventListener(MouseEvent.MOUSE_UP, mouseUp, false, 0, true);
+			STAGE.addEventListener(MouseEvent.MOUSE_MOVE, mouseMove, false, 0, true);
+			STAGE.addEventListener(MouseEvent.MOUSE_UP, mouseUp, false, 0, true);
 			event.stopPropagation();
 		}
 
@@ -68,8 +68,8 @@ package svgeditor.tools
 		}
 
 		private function mouseUp(event:MouseEvent = null):void {
-			editor.stage.removeEventListener(MouseEvent.MOUSE_MOVE, mouseMove);
-			editor.stage.removeEventListener(MouseEvent.MOUSE_UP, mouseUp);
+			STAGE.removeEventListener(MouseEvent.MOUSE_MOVE, mouseMove);
+			STAGE.removeEventListener(MouseEvent.MOUSE_UP, mouseUp);
 		}
 
 		private function grabColor():void {

--- a/src/svgeditor/tools/ObjectTransformer.as
+++ b/src/svgeditor/tools/ObjectTransformer.as
@@ -129,15 +129,8 @@ package svgeditor.tools  {
 			alpha = 0.65;
 		}
 
-		private function getStage():Stage {
-			if (editor && editor.stage) {
-				return editor.stage;
-			}
-			return stage;
-		}
-
 		override protected function shutdown():void {
-			var stageObject:Stage = getStage();
+			var stageObject:Stage = STAGE;
 
 			// Remove event handlers
 			removeSelectionEventHandlers();
@@ -192,7 +185,7 @@ package svgeditor.tools  {
 				preEditTF = targetObj.getObjs()[0] as TextField;
 				preEditTF.type = TextFieldType.INPUT;
 				preEditTF.addEventListener(FocusEvent.FOCUS_IN, handleTextFocus, false, 0, true);
-				stage.focus = null;
+				STAGE.focus = null;
 			}
 		}
 
@@ -281,9 +274,9 @@ package svgeditor.tools  {
 					moveHandler(new MouseEvent(MouseEvent.MOUSE_DOWN), true);
 				}
 
-				toolsLayer.stage.addEventListener(KeyboardEvent.KEY_DOWN, keyPressed, false, 0, true);
+				STAGE.addEventListener(KeyboardEvent.KEY_DOWN, keyPressed, false, 0, true);
 			} else {
-				if(toolsLayer && toolsLayer.stage) toolsLayer.stage.removeEventListener(KeyboardEvent.KEY_DOWN, keyPressed);
+				STAGE.removeEventListener(KeyboardEvent.KEY_DOWN, keyPressed);
 				transform.matrix = new Matrix();
 			}
 
@@ -344,7 +337,7 @@ package svgeditor.tools  {
 		}
 
 		private function removeSelectionEventHandlers():void {
-			var stageObject:Stage = getStage();
+			var stageObject:Stage = STAGE;
 			if (stageObject) {
 				stageObject.removeEventListener(MouseEvent.MOUSE_UP, moveHandler);
 				stageObject.removeEventListener(MouseEvent.MOUSE_UP, resizeHandler);
@@ -360,8 +353,8 @@ package svgeditor.tools  {
 
 		private function keyPressed(e:KeyboardEvent):void {
 			if(isShuttingDown || !editor.isActive()) return;
-			if(stage && (stage.focus is TextField ||
-				(stage.focus is SVGTextField && (stage.focus as SVGTextField).type == TextFieldType.INPUT))) return;
+			if((STAGE.focus is TextField ||
+				(STAGE.focus is SVGTextField && (STAGE.focus as SVGTextField).type == TextFieldType.INPUT))) return;
 
 			var changed:Boolean = true;
 			switch(e.keyCode) {
@@ -515,7 +508,7 @@ package svgeditor.tools  {
 
 		private function updateResizeCursor(handle:Sprite):void {
 			var isDiagonal:Boolean = (scaleHandleDict[handle] as String).length > 6;
-			var r:Rectangle = targetObj.getBounds(stage);
+			var r:Rectangle = targetObj.getBounds(STAGE);
 			var center:Point = new Point((r.left + r.right)/2, (r.top + r.bottom)/2);
 			var up:Point = localToGlobal(new Point(handle.x, handle.y)).subtract(center);
 			up.normalize(1);
@@ -569,7 +562,7 @@ package svgeditor.tools  {
 				case MouseEvent.MOUSE_DOWN:
 					activeHandle = Sprite(e.target);
 					editor.addEventListener(MouseEvent.MOUSE_MOVE, arguments.callee, false, 0, true);
-					stage.addEventListener(MouseEvent.MOUSE_UP, arguments.callee, false, 0, true);
+					STAGE.addEventListener(MouseEvent.MOUSE_UP, arguments.callee, false, 0, true);
 					e.stopPropagation();
 
 					// Reset the center since we're resizing
@@ -587,7 +580,7 @@ package svgeditor.tools  {
 				case MouseEvent.MOUSE_UP:
 					setActive(false);
 					editor.removeEventListener(MouseEvent.MOUSE_MOVE, arguments.callee);
-					stage.removeEventListener(MouseEvent.MOUSE_UP, arguments.callee);
+					STAGE.removeEventListener(MouseEvent.MOUSE_UP, arguments.callee);
 					removeEventListener(MouseEvent.MOUSE_DOWN, arguments.callee);
 					activeHandle = null;
 					targetObj.saveTransform();
@@ -611,7 +604,7 @@ package svgeditor.tools  {
 					if(!targetObj.canMoveByMouse())
 						return;
 					editor.addEventListener(MouseEvent.MOUSE_MOVE, arguments.callee, false, 0, true);
-					stage.addEventListener(MouseEvent.MOUSE_UP, arguments.callee, false, 0, true);
+					STAGE.addEventListener(MouseEvent.MOUSE_UP, arguments.callee, false, 0, true);
 
 					// If they are pressing shift and clicking on the move handle, allow the user
 					// to move the handle (changing the center of rotation for the object)
@@ -626,7 +619,7 @@ package svgeditor.tools  {
 					//break;
 
 				case MouseEvent.MOUSE_MOVE:
-					if(!editor.getCanvasLayer().getBounds(stage).containsPoint(new Point(stage.mouseX, stage.mouseY)))
+					if(!editor.getCanvasLayer().getBounds(STAGE).containsPoint(new Point(STAGE.mouseX, STAGE.mouseY)))
 						break;
 
 					if(moveOffset) {
@@ -653,7 +646,7 @@ package svgeditor.tools  {
 					setActive(false);
 					centerMoved = (moveOffset == null);
 					editor.removeEventListener(MouseEvent.MOUSE_MOVE, arguments.callee);
-					stage.removeEventListener(MouseEvent.MOUSE_UP, arguments.callee);
+					STAGE.removeEventListener(MouseEvent.MOUSE_UP, arguments.callee);
 
 					targetObj.saveTransform();
 
@@ -669,8 +662,8 @@ package svgeditor.tools  {
 		private function rotateHandler(e:MouseEvent):void {
 			switch(e.type) {
 				case MouseEvent.MOUSE_DOWN:
-					stage.addEventListener(MouseEvent.MOUSE_MOVE, arguments.callee, false, 0, true);
-					stage.addEventListener(MouseEvent.MOUSE_UP, arguments.callee, false, 0, true);
+					STAGE.addEventListener(MouseEvent.MOUSE_MOVE, arguments.callee, false, 0, true);
+					STAGE.addEventListener(MouseEvent.MOUSE_UP, arguments.callee, false, 0, true);
 
 					// Make sure we can rotate around the center of the selection
 					e.stopPropagation();
@@ -700,8 +693,8 @@ package svgeditor.tools  {
 
 				case MouseEvent.MOUSE_UP:
 					setActive(false);
-					stage.removeEventListener(MouseEvent.MOUSE_MOVE, arguments.callee);
-					stage.removeEventListener(MouseEvent.MOUSE_UP, arguments.callee);
+					STAGE.removeEventListener(MouseEvent.MOUSE_MOVE, arguments.callee);
+					STAGE.removeEventListener(MouseEvent.MOUSE_UP, arguments.callee);
 					targetObj.saveTransform();
 
 					// The object changed!
@@ -793,8 +786,8 @@ package svgeditor.tools  {
 					// The editor will want to return to the rectangle or ellipse tool if the user clicks outside of the selection and the selection is holding a just-drawn rectangle or ellipse.
 					if (editor.revertToCreateTool(e)) return;
 
-					stage.addEventListener(MouseEvent.MOUSE_MOVE, arguments.callee, false, 0, true);
-					stage.addEventListener(MouseEvent.MOUSE_UP, arguments.callee, false, 0, true);
+					STAGE.addEventListener(MouseEvent.MOUSE_MOVE, arguments.callee, false, 0, true);
+					STAGE.addEventListener(MouseEvent.MOUSE_UP, arguments.callee, false, 0, true);
 					selectionOrigin = editor.snapToGrid(new Point(toolsLayer.mouseX, toolsLayer.mouseY));
 
 					currentEvent = null;
@@ -813,8 +806,8 @@ package svgeditor.tools  {
 
 				case MouseEvent.MOUSE_UP:
 					toolsLayer.graphics.clear();
-					stage.removeEventListener(MouseEvent.MOUSE_MOVE, arguments.callee);
-					stage.removeEventListener(MouseEvent.MOUSE_UP, arguments.callee);
+					STAGE.removeEventListener(MouseEvent.MOUSE_MOVE, arguments.callee);
+					STAGE.removeEventListener(MouseEvent.MOUSE_UP, arguments.callee);
 
 					if (editor is BitmapEdit) {
 						// Compute the selection rectangle relative to the bitmap content.

--- a/src/svgeditor/tools/PaintBrushTool.as
+++ b/src/svgeditor/tools/PaintBrushTool.as
@@ -110,7 +110,7 @@ package svgeditor.tools
 							elem.setAttribute('stroke-width', 2);
 					}
 					obj.redraw(true);
-					isOverStroke = (obj as DisplayObject).hitTestPoint(stage.mouseX, stage.mouseY, true);
+					isOverStroke = (obj as DisplayObject).hitTestPoint(STAGE.mouseX, STAGE.mouseY, true);
 				}
 				else {
 					isOverStroke = false;

--- a/src/svgeditor/tools/PathAnchorPoint.as
+++ b/src/svgeditor/tools/PathAnchorPoint.as
@@ -19,16 +19,11 @@
 
 package svgeditor.tools
 {
-	import flash.display.DisplayObject;
 	import flash.display.Graphics;
 	import flash.display.Sprite;
 	import flash.events.Event;
 	import flash.events.MouseEvent;
 	import flash.geom.Point;
-
-	import svgeditor.ImageEdit;
-	import svgeditor.objs.ISVGEditable;
-	import svgeditor.objs.SVGShape;
 
 	public class PathAnchorPoint extends Sprite
 	{

--- a/src/svgeditor/tools/PathTool.as
+++ b/src/svgeditor/tools/PathTool.as
@@ -60,8 +60,8 @@ package svgeditor.tools
 		override protected function init():void {
 			super.init();
 			if(!linesOnly) {
-				stage.addEventListener(KeyboardEvent.KEY_DOWN, onKeyPress, false, 0, true);
-				stage.addEventListener(KeyboardEvent.KEY_UP, onKeyRelease, false, 0, true);
+				STAGE.addEventListener(KeyboardEvent.KEY_DOWN, onKeyPress, false, 0, true);
+				STAGE.addEventListener(KeyboardEvent.KEY_UP, onKeyRelease, false, 0, true);
 			}
 			editor.getToolsLayer().mouseEnabled = false;
 			mouseEnabled = false;
@@ -72,10 +72,8 @@ package svgeditor.tools
 		}
 
 		override protected function shutdown():void {
-			if(editor.stage) {
-				editor.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);
-				editor.stage.removeEventListener(KeyboardEvent.KEY_UP, onKeyRelease);
-			}
+			STAGE.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);
+			STAGE.removeEventListener(KeyboardEvent.KEY_UP, onKeyRelease);
 			editor.getToolsLayer().mouseEnabled = true;
 			PathEndPointManager.removeEndPoints();
 			if(previewShape.parent) previewShape.parent.removeChild(previewShape);

--- a/src/svgeditor/tools/SVGCreateTool.as
+++ b/src/svgeditor/tools/SVGCreateTool.as
@@ -97,8 +97,8 @@ package svgeditor.tools
 				mouseDown(p);
 				if(isQuick && !isShuttingDown) {
 					// Add the mouse event handlers
-					editor.stage.addEventListener(MouseEvent.MOUSE_MOVE, eventHandler, false, 0, true);
-					editor.stage.addEventListener(MouseEvent.MOUSE_UP, eventHandler, false, 0, true);
+					STAGE.addEventListener(MouseEvent.MOUSE_MOVE, eventHandler, false, 0, true);
+					STAGE.addEventListener(MouseEvent.MOUSE_UP, eventHandler, false, 0, true);
 				}
 				lastPos = p;
 			} else if(e.type == MouseEvent.MOUSE_MOVE) {
@@ -109,7 +109,7 @@ package svgeditor.tools
 				if(!stage) return;
 
 				// If the mouse came up outside of the canvas, use the last mouse position within the canvas
-				if(!editor.getCanvasLayer().hitTestPoint(stage.mouseX, stage.mouseY, true))
+				if(!editor.getCanvasLayer().hitTestPoint(STAGE.mouseX, STAGE.mouseY, true))
 					p = lastPos;
 
 				mouseUp(p);
@@ -120,17 +120,15 @@ package svgeditor.tools
 		private function addEventHandlers():void  {
 			editor.getCanvasLayer().addEventListener(MouseEvent.MOUSE_DOWN, eventHandler, false, 0, true);
 			if(!isQuick) {
-				editor.stage.addEventListener(MouseEvent.MOUSE_MOVE, eventHandler, false, 0, true);
-				editor.stage.addEventListener(MouseEvent.MOUSE_UP, eventHandler, false, 0, true);
+				STAGE.addEventListener(MouseEvent.MOUSE_MOVE, eventHandler, false, 0, true);
+				STAGE.addEventListener(MouseEvent.MOUSE_UP, eventHandler, false, 0, true);
 			}
 		}
 
 		private function removeEventHandlers():void {
 			editor.getCanvasLayer().removeEventListener(MouseEvent.MOUSE_DOWN, eventHandler);
-			if(editor.stage) {
-				editor.stage.removeEventListener(MouseEvent.MOUSE_MOVE, eventHandler);
-				editor.stage.removeEventListener(MouseEvent.MOUSE_UP, eventHandler);
-			}
+			STAGE.removeEventListener(MouseEvent.MOUSE_MOVE, eventHandler);
+			STAGE.removeEventListener(MouseEvent.MOUSE_UP, eventHandler);
 		}
 	}
 }

--- a/src/svgeditor/tools/SVGTool.as
+++ b/src/svgeditor/tools/SVGTool.as
@@ -19,134 +19,134 @@
 
 package svgeditor.tools
 {
-	import flash.display.DisplayObject;
-	import flash.display.Sprite;
-	import flash.events.Event;
-	import flash.events.MouseEvent;
-	import flash.geom.Point;
+import flash.display.DisplayObject;
+import flash.display.Sprite;
+import flash.display.Stage;
+import flash.events.Event;
+import flash.events.MouseEvent;
+import flash.geom.Point;
 
-	import svgeditor.ImageEdit;
-	import svgeditor.objs.*;
+import svgeditor.ImageEdit;
+import svgeditor.objs.*;
+import svgutils.SVGPath;
 
-	import svgutils.SVGPath;
+public class SVGTool extends Sprite
+{
+	static protected var STAGE:Stage;
+	static public function setStage(s:Stage):void { STAGE = s; }
 
-	public class SVGTool extends Sprite
-	{
-		protected var editor:ImageEdit;
-		protected var isShuttingDown:Boolean;
-		protected var currentEvent:MouseEvent;
-		protected var cursorBMName:String;
-		protected var cursorName:String;
-		protected var cursorHotSpot:Point;
-		protected var touchesContent:Boolean;
+	protected var editor:ImageEdit;
+	protected var isShuttingDown:Boolean;
+	protected var currentEvent:MouseEvent;
+	protected var cursorBMName:String;
+	protected var cursorName:String;
+	protected var cursorHotSpot:Point;
+	protected var touchesContent:Boolean;
 
-		public function SVGTool(ed:ImageEdit) {
-			editor = ed;
-			isShuttingDown = false;
-			touchesContent = false;
+	public function SVGTool(ed:ImageEdit) {
+		editor = ed;
+		isShuttingDown = false;
+		touchesContent = false;
 
-			addEventListener(Event.ADDED_TO_STAGE, addedToStage);
-			addEventListener(Event.REMOVED, removedFromStage);
-		}
-
-		public function refresh():void {}
-
-		protected function init():void {
-			if(cursorBMName && cursorHotSpot)
-				editor.setCurrentCursor(cursorBMName, cursorBMName, cursorHotSpot);
-			else if(cursorName)
-				editor.setCurrentCursor(cursorName);
-		}
-
-		protected function shutdown():void {
-			editor.setCurrentCursor(null);
-			editor = null;
-		}
-
-		public final function interactsWithContent():Boolean {
-			return touchesContent;
-		}
-
-		public function cancel():void {
-			if(parent) parent.removeChild(this);
-		}
-
-		private function addedToStage(e:Event):void {
-			removeEventListener(Event.ADDED_TO_STAGE, addedToStage);
-			init();
-		}
-
-		private function removedFromStage(e:Event):void {
-			if(e.target != this) return;
-
-			removeEventListener(Event.REMOVED, removedFromStage);
-			isShuttingDown = true;
-			shutdown();
-		}
-
-		protected function getEditableUnderMouse(includeGroups:Boolean = true):ISVGEditable {
-			return staticGetEditableUnderMouse(editor, includeGroups, this);
-		}
-
-		static public function staticGetEditableUnderMouse(editor:ImageEdit, includeGroups:Boolean = true, currentTool:SVGTool = null):ISVGEditable {
-			if(!editor.stage) return null;
-
-			var objs:Array = editor.stage.getObjectsUnderPoint(new Point(editor.stage.mouseX, editor.stage.mouseY));
-
-			// Select the top object that is ISVGEditable
-			if(objs.length) {
-				// Try to find the topmost element whose parent is the selection context
-				for(var i:int = objs.length - 1; i>=0; --i) {
-					var rawObj:DisplayObject = objs[i];
-					var obj:DisplayObject = getChildOfSelectionContext(rawObj, editor);
-
-					// If we're not including groups and a group was selected, try to select the object under
-					// the mouse if it's parent is the group found.
-					if(!includeGroups && obj is SVGGroup && rawObj.parent is SVGGroup && rawObj is ISVGEditable)
-						obj = rawObj;
-
-					var isPaintBucket:Boolean = (currentTool is PaintBucketTool || currentTool is PaintBrushTool);
-					var isOT:Boolean = (currentTool is ObjectTransformer);
-					if(obj is ISVGEditable && (includeGroups || !(obj is SVGGroup)) && (isPaintBucket || !(obj as ISVGEditable).getElement().isBackDropBG())) {
-						return (obj as ISVGEditable);
-					}
-				}
-			}
-
-			return null;
-		}
-
-		static private function getChildOfSelectionContext(obj:DisplayObject, editor:ImageEdit):DisplayObject {
-			var contentLayer:Sprite = editor.getContentLayer();
-			while(obj && obj.parent != contentLayer) obj = obj.parent;
-			return obj;
-		}
-
-		// Used by the PathEditTool and PathTool
-		protected function getContinuableShapeUnderMouse(strokeWidth:Number):Object {
-			// Hide the current path so we don't get that
-			var obj:ISVGEditable = getEditableUnderMouse(false);
-
-			if(obj is SVGShape) {
-				var s:SVGShape = obj as SVGShape;
-				var path:SVGPath = s.getElement().path;
-				var segment:Array = path.getSegmentEndPoints(0);
-				var isClosed:Boolean = segment[2];
-				var otherWidth:Number = s.getElement().getAttribute('stroke-width', 1);
-				var w:Number = (strokeWidth + otherWidth) / 2;
-				if(!isClosed) {
-					var m:Point = new Point(s.mouseX, s.mouseY);
-					var p:Point = null;
-					if(path.getPos(segment[0]).subtract(m).length < w) {
-						return {index: segment[0], bEnd: false, shape: (obj as SVGShape)};
-					}
-					else if(path.getPos(segment[1]).subtract(m).length < w) {
-						return {index: segment[1], bEnd: true, shape: (obj as SVGShape)};
-					}
-				}
-			}
-
-			return null;
-		}
+		addEventListener(Event.ADDED_TO_STAGE, addedToStage);
+		addEventListener(Event.REMOVED, removedFromStage);
 	}
-}
+
+	public function refresh():void {}
+
+	protected function init():void {
+		if(cursorBMName && cursorHotSpot)
+			editor.setCurrentCursor(cursorBMName, cursorBMName, cursorHotSpot);
+		else if(cursorName)
+			editor.setCurrentCursor(cursorName);
+	}
+
+	protected function shutdown():void {
+		editor.setCurrentCursor(null);
+		editor = null;
+	}
+
+	public final function interactsWithContent():Boolean {
+		return touchesContent;
+	}
+
+	public function cancel():void {
+		if(parent) parent.removeChild(this);
+	}
+
+	private function addedToStage(e:Event):void {
+		removeEventListener(Event.ADDED_TO_STAGE, addedToStage);
+		init();
+	}
+
+	private function removedFromStage(e:Event):void {
+		if(e.target != this) return;
+
+		removeEventListener(Event.REMOVED, removedFromStage);
+		isShuttingDown = true;
+		shutdown();
+	}
+
+	protected function getEditableUnderMouse(includeGroups:Boolean = true):ISVGEditable {
+		return staticGetEditableUnderMouse(editor, includeGroups, this);
+	}
+
+	static public function staticGetEditableUnderMouse(editor:ImageEdit, includeGroups:Boolean = true, currentTool:SVGTool = null):ISVGEditable {
+		var objs:Array = STAGE.getObjectsUnderPoint(new Point(STAGE.mouseX, STAGE.mouseY));
+
+		// Select the top object that is ISVGEditable
+		if(objs.length) {
+			// Try to find the topmost element whose parent is the selection context
+			for(var i:int = objs.length - 1; i>=0; --i) {
+				var rawObj:DisplayObject = objs[i];
+				var obj:DisplayObject = getChildOfSelectionContext(rawObj, editor);
+
+				// If we're not including groups and a group was selected, try to select the object under
+				// the mouse if it's parent is the group found.
+				if(!includeGroups && obj is SVGGroup && rawObj.parent is SVGGroup && rawObj is ISVGEditable)
+					obj = rawObj;
+
+				var isPaintBucket:Boolean = (currentTool is PaintBucketTool || currentTool is PaintBrushTool);
+				var isOT:Boolean = (currentTool is ObjectTransformer);
+				if(obj is ISVGEditable && (includeGroups || !(obj is SVGGroup)) && (isPaintBucket || !(obj as ISVGEditable).getElement().isBackDropBG())) {
+					return (obj as ISVGEditable);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	static private function getChildOfSelectionContext(obj:DisplayObject, editor:ImageEdit):DisplayObject {
+		var contentLayer:Sprite = editor.getContentLayer();
+		while(obj && obj.parent != contentLayer) obj = obj.parent;
+		return obj;
+	}
+
+	// Used by the PathEditTool and PathTool
+	protected function getContinuableShapeUnderMouse(strokeWidth:Number):Object {
+		// Hide the current path so we don't get that
+		var obj:ISVGEditable = getEditableUnderMouse(false);
+
+		if(obj is SVGShape) {
+			var s:SVGShape = obj as SVGShape;
+			var path:SVGPath = s.getElement().path;
+			var segment:Array = path.getSegmentEndPoints(0);
+			var isClosed:Boolean = segment[2];
+			var otherWidth:Number = s.getElement().getAttribute('stroke-width', 1);
+			var w:Number = (strokeWidth + otherWidth) / 2;
+			if(!isClosed) {
+				var m:Point = new Point(s.mouseX, s.mouseY);
+				var p:Point = null;
+				if(path.getPos(segment[0]).subtract(m).length < w) {
+					return {index: segment[0], bEnd: false, shape: (obj as SVGShape)};
+				}
+				else if(path.getPos(segment[1]).subtract(m).length < w) {
+					return {index: segment[1], bEnd: true, shape: (obj as SVGShape)};
+				}
+			}
+		}
+
+		return null;
+	}
+}}

--- a/src/svgeditor/tools/TextTool.as
+++ b/src/svgeditor/tools/TextTool.as
@@ -54,7 +54,7 @@ package svgeditor.tools
 
 		override protected function init():void {
 			super.init();
-			if(object) stage.focus = object as SVGTextField;
+			if(object) STAGE.focus = object as SVGTextField;
 			editor.getContentLayer().removeEventListener(MouseEvent.MOUSE_DOWN, mouseDown);
 			editor.getWorkArea().addEventListener(MouseEvent.MOUSE_DOWN, mouseDown, false, 0, true);
 			created = false;
@@ -70,7 +70,7 @@ package svgeditor.tools
 			if(e is KeyboardEvent) {
 				var kbe:KeyboardEvent = (e as KeyboardEvent);
 				if(kbe.keyCode == 27) { //  || kbe.keyCode == 13
-					stage.focus = null;
+					STAGE.focus = null;
 					editor.endCurrentTool(object);
 					e.stopImmediatePropagation();
 				}
@@ -104,7 +104,7 @@ package svgeditor.tools
 			}
 			tf.addEventListener(KeyboardEvent.KEY_DOWN, handleEvents, false, 0, true);
 			tf.addEventListener(Event.CHANGE, handleEvents, false, 0, true);
-			if(stage && stage.focus != tf) stage.focus = tf;
+			if(STAGE.focus != tf) STAGE.focus = tf;
 			if(tf.text == " ") tf.text = "";
 			if(editor is SVGEdit) tf.filters = [new DropShadowFilter(4, 45, 0, 0.3)];
 


### PR DESCRIPTION
Fixes an null reference error we've been seeing in the editor. Here is how you can cause it to happen before this change: create new project, click on icon to create a new sprite (paint brush icon), switch to scripts tab, click on help (?) at the top.

Here is the stack trace:
Error #1009 Root Cause
(Unknown file) ? in svgeditor.tools::BitmapPencilTool/shutdown()
(Unknown file) ? in svgeditor.tools::SVGTool/removedFromStage()
(Unknown file) ? in svgeditor::ImageEdit/setToolMode()
(Unknown file) ? in svgeditor::BitmapEdit/setToolMode()
(Unknown file) ? in svgeditor::ImageEdit/enableTools()
(Unknown file) ? in Scratch/enableEditorTools()
(Unknown file) ? in uiwidgets::CursorTool$/setTool()
(Unknown file) ? in MethodInfo-1176()
(Unknown file) ? in uiwidgets::IconButton/mouseDown()