### PR TITLE
Call resetPlugin before installing project or loading extensions.

### DIFF
--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -448,6 +448,7 @@ public class ScratchRuntime {
 			if (spr) spr.setDirection(spr.direction);
 		}
 
+		if (Scratch.app.jsEnabled) Scratch.app.externalCall('ScratchExtensions.resetPlugin');
 		app.extensionManager.clearImportedExtensions();
 		app.extensionManager.loadSavedExtensions(project.info.savedExtensions);
 		app.installStage(project);


### PR DESCRIPTION
Fixes an issue we're seeing with the WeDo in workshops.