### PR TITLE
Do not permanently delete internal extensions

### DIFF
--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -101,7 +101,7 @@ public class ExtensionManager {
 				}
 				else {
 					app.externalCall('ScratchExtensions.unregister', null, extName);
-					delete extensionDict[extName];
+					if(!ext.isInternal) delete extensionDict[extName];
 				}
 			}
 		}


### PR DESCRIPTION
Internal extensions should only hide/show blocks, not be permanently deleted, as this stops add-remove-add of that extension from working.