### PR TITLE
Always check the buffers when rendering an individual child.

### DIFF
--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -1062,7 +1062,6 @@ public class DisplayObjectContainerIn3D extends Sprite implements IRenderIn3D {S
 		if (!spriteBitmaps[dispObj] || unrenderedChildren[dispObj] || !bitmapsByID[spriteBitmaps[dispObj]]) {
 			if (checkChildRender(dispObj)) {
 				packTextureBitmaps();
-				checkBuffers();
 			}
 		}
 
@@ -1132,6 +1131,7 @@ public class DisplayObjectContainerIn3D extends Sprite implements IRenderIn3D {S
 
 		// TODO: Find out why the index buffer isn't uploaded sometimes
 		indexBufferUploaded = false;
+		checkBuffers();
 		uploadBuffers();
 
 		var changeBackBuffer:Boolean = (bmd.width > scissorRect.width || bmd.height > scissorRect.height);


### PR DESCRIPTION
Fixes an exception that sometimes occurs when ScratchSprite.bitmap() is called and 3d rendering is enabled.

Call stack:
(Unknown file) ? in render3d::DisplayObjectContainerIn3D/uploadBuffers()
(Unknown file) ? in render3d::DisplayObjectContainerIn3D/getRenderedChild()
(Unknown file) ? in scratch::ScratchSprite/bitmap()
(Unknown file) ? in scratch::ScratchSprite/bounds()
(Unknown file) ? in scratch::ScratchSprite/hitTestPoint()
(Unknown file) ? in util::GestureHandler/findMouseTargetOnStage()
(Unknown file) ? in util::GestureHandler/findMouseTarget()
(Unknown file) ? in util::GestureHandler/mouseDown()