### PR TITLE
Honor resolution setting if present in JSON

### DIFF
--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -440,8 +440,11 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 
 					io.fetchImage(md5AndExt, item.dbObj.name, 0, whenDone, obj);
 				} else { // assetType == backdrop
-					if (item.dbObj.info.length == 2 && item.dbObj.info[0] == 960 && item.dbObj.info[1] == 720)
-						obj = { centerX: 99999, centerY: 99999,	bitmapResolution: 2 };
+					if (item.dbObj.info.length == 3) {
+						obj = {centerX: 99999, centerY: 99999, bitmapResolution: item.dbObj.info[2]};
+					} else if (item.dbObj.info.length == 2 && item.dbObj.info[0] == 960 && item.dbObj.info[1] == 720) {
+						obj = {centerX: 99999, centerY: 99999, bitmapResolution: 2};
+					}
 					io.fetchImage(md5AndExt, item.dbObj.name, 0, whenDone, obj);
 				}
 			}


### PR DESCRIPTION
The backdrop JSON can optionally specify the bitmap resolution to use
for a given backdrop. Previously this setting ws ignored on backdrops
and would even prevent the detection of a high-resolution backdrop. Now
it is honored if present, and if absent then the automatic resolution
detection still works.
Fixes #672 (again).