### PR TITLE
Remove recursive descent through blocks when checking for extension blocking conditions

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -81,6 +81,7 @@ public class Block extends Sprite {
 	public var requestState:int = 0;		// 0 - no request made, 1 - awaiting response, 2 - data ready
 	public var response:* = null;
 	public var requestLoader:URLLoader = null;
+	public var blockingCount:int = 0;
 
 	public var nextBlock:Block;
 	public var subStack1:Block;
@@ -1016,5 +1017,50 @@ public class Block extends Sprite {
 	protected static function indent(s:String):String {
 		return s.replace(/^/gm, "    ");
 	}
+
+	/* Blocking */
+
+	public function resetBlockingCount():void {
+		// should be called for a top stack block - resets all blocks in stack
+		resetArgsBlockingCount();
+		if(subStack1) subStack1.resetBlockingCount();
+		if(subStack2) subStack2.resetBlockingCount();
+		if(nextBlock) nextBlock.resetBlockingCount();
+	}
+
+	public function resetArgsBlockingCount():void {
+		// descend through all block's args, resetting to zero
+		blockingCount = 0;
+		var args:Array = this.args;
+		for(var i:uint=0; i<args.length; ++i) {
+			var barg:Block = args[i] as Block;
+			if(barg) barg.resetArgsBlockingCount();
+		}
+	}
+
+	public function increaseBlockingCount():void {
+		// increase blockingCount up the chain
+		// TLF: is it only the top level block that needs changing?
+		var b:Block = this;
+		while (true) {
+			b.blockingCount++;
+			if (b.parent is Block) b = Block(b.parent)
+			else return;
+		}
+		return; // never gets here
+	}
+
+	public function decreaseBlockingCount():void {
+		// decrease blockingCount up the chain
+		// TLF: is it only the top level block that needs changing?
+		var b:Block = this;
+		while (true) {
+			if(b.blockingCount>0) b.blockingCount--; // TLF: just in case...
+			if (b.parent is Block) b = Block(b.parent)
+			else return;
+		}
+		return; // never gets here
+	}
+
 
 }}

--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -303,8 +303,9 @@ public class Interpreter {
 			else b.opFunction = (primTable[op] == undefined) ? primNoop : primTable[op];
 		}
 
-		// TODO: Optimize this into a cached check if the args *could* block at all
-		if(b.args.length && checkBlockingArgs(b)) {
+		// TLF: blockingCount value is propagated up through blocks, so only
+		// need to yield if it finds a non-zero blockingCount
+		if(b.blockingCount) {
 			doYield();
 			return null;
 		}

--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -318,7 +318,7 @@ public class Interpreter {
 	}
 
 	// Returns true if the thread needs to yield while data is requested
-	public function checkBlockingArgs(b:Block):Boolean {
+/*	public function checkBlockingArgs(b:Block):Boolean {
 		// Do any of the arguments request data?  If so, start any requests and yield.
 		var shouldYield:Boolean = false;
 		var args:Array = b.args;
@@ -337,7 +337,7 @@ public class Interpreter {
 		}
 
 		return shouldYield;
-	}
+	}*/
 
 	public function arg(b:Block, i:int):* {
 		var args:Array = b.args;

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -151,6 +151,8 @@ public class ScratchRuntime {
 		clearAskPrompts();
 		app.removeLoadProgressBox();
 		motionDetector = null;
+		// TLF: should a clicked stack also clear its blockingCounts before running?
+		resetAllBlockingCounts();
 	}
 
 	// -----------------------------
@@ -870,6 +872,14 @@ public class ScratchRuntime {
 			}
 		});
 		clearAllCaches();
+	}
+
+	public function resetAllBlockingCounts():void {
+		// reset blockingCount for all blocks in each stack
+		var stackList:Array = allStacks();
+		for each (var stack:Block in stackList) {
+			if(stack) stack.resetBlockingCount(); // TLF: can it ever give null stack...?
+		}
 	}
 
 	public function allStacks():Array {


### PR DESCRIPTION
Not got any experience with extensions, so I don't know if this is all done correctly.
In particular, there are numerous questions I've put into various comments.

However, it knocks off a decent chunk of time from raw block processing, so I'm hoping this will at least form the basis for a method to avoid that recursive checkBlockingArgs call (and I've just realised that function itself is still in there but should be removable now...)
