### PR TITLE
Calculate new MD5 sums immediately when base/textLayerData change

### DIFF
--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -110,7 +110,7 @@ public class ScratchCostume {
 
 	public function set baseLayerData(data:ByteArray):void {
 		__baseLayerData = data;
-		baseLayerMD5 = by.blooddy.crypto.MD5.hashBytes(data) + fileExtension(data);
+		baseLayerMD5 = data ? by.blooddy.crypto.MD5.hashBytes(data) + fileExtension(data) : null;
 	}
 
 	public function get textLayerData():ByteArray {
@@ -119,7 +119,7 @@ public class ScratchCostume {
 
 	public function set textLayerData(data:ByteArray):void {
 		__textLayerData = data;
-		textLayerMD5 = by.blooddy.crypto.MD5.hashBytes(data) + '.png';
+		textLayerMD5 = data ? by.blooddy.crypto.MD5.hashBytes(data) + '.png' : null;
 	}
 
 	public static function scaleForScratch(bm:BitmapData):BitmapData {

--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -110,7 +110,7 @@ public class ScratchCostume {
 
 	public function set baseLayerData(data:ByteArray):void {
 		__baseLayerData = data;
-		baseLayerMD5 = null;
+		baseLayerMD5 = by.blooddy.crypto.MD5.hashBytes(data) + fileExtension(data);
 	}
 
 	public function get textLayerData():ByteArray {
@@ -119,7 +119,7 @@ public class ScratchCostume {
 
 	public function set textLayerData(data:ByteArray):void {
 		__textLayerData = data;
-		textLayerMD5 = null;
+		textLayerMD5 = by.blooddy.crypto.MD5.hashBytes(data) + '.png';
 	}
 
 	public static function scaleForScratch(bm:BitmapData):BitmapData {


### PR DESCRIPTION
This appears to fix both https://github.com/LLK/scratch-flash/issues/781 and https://github.com/LLK/scratch-flash/issues/750

In the case of https://scratch.mit.edu/projects/64857642/ (referenced in #781 above), it speeds up the non-empty costume case (middle one) by a factor of 10x or so, which is just what is seen immediately after saving the project (because the MD5s are then set correctly...)

I'm not sure I entirely understand how this base/textLayerData setter is meant to work, but it seems like it isn't working as intended with the MD5 sums at the moment because they are not getting set correctly somehow, so the shape is not getting cached except right after saving, which means costume switching is much slower than it could be unless the project was just saved. Also, it affects other things too, as seen in the rotation issue (#750).