### PR TITLE
Adds new item "go to definition" for drop-down menus of custom block callers

### DIFF
--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -534,22 +534,21 @@ public class BlockMenus implements DragClient {
 		addGenericBlockItems(m);
 		m.addItem('edit', editProcSpec);
 		if (block.op==Specs.CALL) {
-			/// TLF: alternative text? -maybe "show definition"...?
-			m.addItem('go to definition', gotoProcSpec);
+			m.addItem('see the define script', jumpToProcDef);
 		}
 		showMenu(m);
 	}
 
-	private function gotoProcSpec():void {
+	private function jumpToProcDef():void {
 		if(!app.editMode) return;
 		if (block.op != Specs.CALL) return;
 		var def:Block = app.viewedObj().lookupProcedure(block.spec);
 		if (!def) return;
 		var pane:ScriptsPane = def.parent as ScriptsPane;
-        if (!pane) return;
+		if (!pane) return;
 		if (pane.parent is ScrollFrame) {
-		   pane.x = 5-def.x*pane.scaleX;
-		   pane.y = 5-def.y*pane.scaleX;
+		   pane.x = 5 - def.x*pane.scaleX;
+		   pane.y = 5 - def.y*pane.scaleX;
 		   (pane.parent as ScrollFrame).constrainScroll();
 		   (pane.parent as ScrollFrame).updateScrollbars();
 		}

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -533,7 +533,26 @@ public class BlockMenus implements DragClient {
 		var m:Menu = new Menu(null, 'proc');
 		addGenericBlockItems(m);
 		m.addItem('edit', editProcSpec);
+		if (block.op==Specs.CALL) {
+			/// TLF: alternative text? -maybe "show definition"...?
+			m.addItem('go to definition', gotoProcSpec);
+		}
 		showMenu(m);
+	}
+
+	private function gotoProcSpec():void {
+		if(!app.editMode) return;
+		if (block.op != Specs.CALL) return;
+		var def:Block = app.viewedObj().lookupProcedure(block.spec);
+		if (!def) return;
+		var pane:ScriptsPane = def.parent as ScriptsPane;
+        if (!pane) return;
+		if (pane.parent is ScrollFrame) {
+		   pane.x = 5-def.x*pane.scaleX;
+		   pane.y = 5-def.y*pane.scaleX;
+		   (pane.parent as ScrollFrame).constrainScroll();
+		   (pane.parent as ScrollFrame).updateScrollbars();
+		}
 	}
 
 	private function editProcSpec():void {

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -534,7 +534,7 @@ public class BlockMenus implements DragClient {
 		addGenericBlockItems(m);
 		m.addItem('edit', editProcSpec);
 		if (block.op==Specs.CALL) {
-			m.addItem('see the define script', jumpToProcDef);
+			m.addItem('define', jumpToProcDef);
 		}
 		showMenu(m);
 	}


### PR DESCRIPTION
Really missed having this! -And so simple to add, too...

Not sure about the best text for it. Currently used "go to definition", but maybe "show definition"?
(It's a pity that, in English, the word 'definition' seems so different to the word 'define', as used on the block definition - makes the link potentially not quite so clear.)

I guess translations will need adding for it...
