### PR TITLE
Fast access for variables via direct index in block.

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -96,6 +96,7 @@ public class Scratch extends Sprite {
 	protected var wasEdited:Boolean; // true if the project was edited and autosaved
 	private var _usesUserNameBlock:Boolean = false;
 	protected var languageChanged:Boolean; // set when language changed
+	public var varsAreDirty:Boolean = true;  // cleaned when stop/GF clicked
 
 	// UI Elements
 	public var playerBG:Shape;

--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -64,6 +64,7 @@ public class Block extends Sprite {
 	public var type:String;
 	public var op:String = "";
 	public var opFunction:Function;
+	public var variableIndex:int = 0;  // cache of variable index
 	public var args:Array = [];
 	public var defaultArgValues:Array = [];
 	public var parameterIndex:int = -1;	// cache of parameter index, used by GET_PARAM block

--- a/src/interpreter/Variable.as
+++ b/src/interpreter/Variable.as
@@ -31,10 +31,17 @@ public class Variable {
 	public var value:*;
 	public var watcher:*;
 	public var isPersistent:Boolean;
+	// The following is the variable's position (1-based) in its owner's
+	// variable list. If the variable is global (i.e.Stage) then negative.
+	// This value is placed into a block's variableIndex to provide a very
+	// quick way to reference the variable.
+	// It cannot be relied upon if app.varsAreDirty is true.
+	public var pos:int = 0;
 
-	public function Variable(vName:String, initialValue:*) {
+	public function Variable(vName:String, initialValue:*, vPos:int) {
 		name = vName;
 		value = initialValue;
+		pos = vPos;
 	}
 
 	public function writeJSON(json:util.JSON):void {

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -678,6 +678,7 @@ public class BlockMenus implements DragClient {
 
 	private function setBlockVarOrListName(newName:String):void {
 		if (newName.length == 0) return;
+		block.variableIndex = 0;  // need to force new lookup
 		if ((block.op == Specs.GET_VAR) || (block.op == Specs.SET_VAR) || (block.op == Specs.CHANGE_VAR)) {
 			app.runtime.createVariable(newName);
 		}

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -144,10 +144,13 @@ public class ScratchRuntime {
 		ScratchSoundPlayer.stopAllSounds();
 		app.extensionManager.stopButtonPressed();
 		app.stagePane.clearFilters();
+		app.stagePane.resetVarIndex(true);
 		for each (var s:ScratchSprite in app.stagePane.sprites()) {
 			s.clearFilters();
 			s.hideBubble();
+			s.resetVarIndex(false);
 		}
+		app.varsAreDirty = false;  // index positions consistent now, ready to cache
 		clearAskPrompts();
 		app.removeLoadProgressBox();
 		motionDetector = null;
@@ -629,7 +632,7 @@ public class ScratchRuntime {
 	}
 
 	public function updateVariable(v:Variable):void {}
-	public function makeVariable(varObj:Object):Variable { return new Variable(varObj.name, varObj.value); }
+	public function makeVariable(varObj:Object):Variable { return new Variable(varObj.name, varObj.value, varObj.pos); }
 	public function makeListWatcher():ListWatcher { return new ListWatcher(); }
 
 	private function updateVarRefs(oldName:String, newName:String, owner:ScratchObj):void {

--- a/src/scratch/ScratchSprite.as
+++ b/src/scratch/ScratchSprite.as
@@ -114,7 +114,12 @@ public class ScratchSprite extends ScratchObj {
 		// Copy variables and lists.
 		for (i = 0; i < spr.variables.length; i++) {
 			var v:Variable = spr.variables[i];
-			variables.push(new Variable(v.name, v.value));
+			if (v.pos>0 && v.pos!=i+1) {  // should never happen...
+				trace( 'incosistent var index: '+v.pos+' vs '+(i+1) );
+				v.pos = 0;
+				spr.variables[i].pos = 0;  // fix this too, to be safe
+			}
+			variables.push(new Variable(v.name, v.value, v.pos));
 		}
 		for (i = 0; i < spr.lists.length; i++) {
 			var lw:ListWatcher = spr.lists[i];

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -827,6 +827,8 @@ public class ScratchStage extends ScratchObj {
 		for each (var scratchObj:ScratchObj in allObjects()) {
 			scratchObj.instantiateFromJSON(this);
 		}
+
+		Scratch.app.varsAreDirty = false;  // should be ok just after reading project
 	}
 
 	public override function getSummary():String {

--- a/src/util/OldProjectReader.as
+++ b/src/util/OldProjectReader.as
@@ -55,7 +55,7 @@ public class OldProjectReader {
 				stageContents = entry[5];
 				newStage = entry[0];
 				newStage.objName = entry[9];
-				newStage.variables = buildVars(entry[10]);
+				newStage.variables = buildVars(entry[10],true);
 				newStage.scripts = buildScripts(entry[11]);
 				newStage.scriptComments = buildComments(entry[11]);
 				fixCommentRefs(newStage.scriptComments, newStage.scripts)
@@ -85,7 +85,7 @@ public class OldProjectReader {
 			*/
 				var s:ScratchSprite = entry[0];
 				s.objName = entry[9];
-				s.variables = buildVars(entry[10]);
+				s.variables = buildVars(entry[10],false);
 				s.scripts = buildScripts(entry[11]);
 				s.scriptComments = buildComments(entry[11]);
 				fixCommentRefs(s.scriptComments, s.scripts)
@@ -147,11 +147,12 @@ public class OldProjectReader {
 		}
 	}
 
-	private function buildVars(pairs:Array):Array {
+	private function buildVars(pairs:Array,forStage:Boolean):Array {
 		if (pairs == null) return [];
 		var result:Array = [];
+		var fact:int = forStage ? -1 : 1;
 		for (var i:int = 0; i < (pairs.length - 1); i += 2) {
-			result.push(new Variable(pairs[i], pairs[i + 1]));
+			result.push(new Variable(pairs[i], pairs[i + 1], fact*(i/2+1)));
 		}
 		return result;
 	}


### PR DESCRIPTION
Each variable keeps track of its index in its owner's variable list (1-based position, and negative if global, i.e. on stage).
This index is consistent, most of the time, across clones, and so can be used by the block for fast access. This is not true under certain conditions - in particular, when a sprite/clone dynamically creates its own variables while running script, and when the user deletes a variable. These cases are dealt with by setting a zero index for dynamically created vars (so the block doesn't access them directly), and by a new application-wide Boolean 'varsAreDirty', which is set true when a variable is deleted. However, on clicking GF or stop, this boolean is cleared, along with all block index caches which then become ready to be refilled on next run (since there are no longer any clones that can cause inconsistent indexing).

If ever Scratch provides capability for dynamic deletion of variables, this method will become less useful...

In terms of speedup, it brings variable access in line with the speed of custom block param access (see https://scratch.mit.edu/projects/40989674/).
It’s worth testing this change on some of my speedtest projects: https://scratch.mit.edu/studios/795672/ The improvement for raw block-processing (i.e. not things to do with bitmaps, etc.) is around 10-20%.

Together with https://github.com/LLK/scratch-flash/pull/795 and https://github.com/LLK/scratch-flash/pull/796 (if that can be sorted out correctly), there's a substantial speed increase all around.
