### PR TITLE
Optimisations for hat block processing

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -559,6 +559,7 @@ public class Block extends Sprite {
 			dup.fixExpressionLayout();
 			dup.fixStackLayout();
 		}
+		Scratch.app.runtime.clearAllHatCaches();
 		return dup;
 	}
 
@@ -816,6 +817,7 @@ public class Block extends Sprite {
 		newStack.x = p.x + deltaX;
 		newStack.y = p.y + deltaY;
 		Scratch.app.gh.grabOnMouseUp(newStack);
+		Scratch.app.runtime.clearAllHatCaches();
 	}
 
 	public function deleteStack():Boolean {
@@ -842,6 +844,7 @@ public class Block extends Sprite {
 		app.runtime.recordForUndelete(this, x, y, 0, app.viewedObj());
 		app.scriptsPane.saveScripts();
 		SCRATCH::allow3d { app.runtime.checkForGraphicEffects(); }
+		app.runtime.clearAllHatCaches();
 		app.updatePalette();
 		return true;
 	}

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -742,8 +742,12 @@ public class BlockMenus implements DragClient {
 
 	private function broadcastMenu(evt:MouseEvent):void {
 		function broadcastMenuSelection(selection:*):void {
-			if (selection is Function) selection();
-			else setBlockArg(selection);
+			if (selection is Function) {
+				selection();
+			} else {
+				setBlockArg(selection);
+				app.runtime.clearAllReceiverCaches();
+			}
 		}
 		var msgNames:Array = app.runtime.collectBroadcasts();
 		if (msgNames.indexOf('message1') <= -1) msgNames.push('message1');
@@ -761,6 +765,7 @@ public class BlockMenus implements DragClient {
 			var newName:String = dialog.getField('Message Name');
 			if (newName.length == 0) return;
 			setBlockArg(newName);
+			app.runtime.clearAllReceiverCaches();
 		}
 		var d:DialogBox = new DialogBox(changeBroadcast);
 		d.addTitle('New Message');

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -200,6 +200,8 @@ public class BlockMenus implements DragClient {
 	private function setBlockArg(selection:*):void {
 		if (blockArg != null) blockArg.setArgValue(selection);
 		Scratch.app.setSaveNeeded();
+		// rebuild receiver caches need rebuild if this was a receiver/backdrop-switched hat block
+		if (block.op=='whenSceneStarts' || block.op=='whenIReceive') app.runtime.clearAllReceiverCaches();
 		SCRATCH::allow3d { Scratch.app.runtime.checkForGraphicEffects(); }
 	}
 
@@ -742,12 +744,8 @@ public class BlockMenus implements DragClient {
 
 	private function broadcastMenu(evt:MouseEvent):void {
 		function broadcastMenuSelection(selection:*):void {
-			if (selection is Function) {
-				selection();
-			} else {
-				setBlockArg(selection);
-				app.runtime.clearAllReceiverCaches();
-			}
+			if (selection is Function) selection();
+			else setBlockArg(selection);
 		}
 		var msgNames:Array = app.runtime.collectBroadcasts();
 		if (msgNames.indexOf('message1') <= -1) msgNames.push('message1');
@@ -765,7 +763,6 @@ public class BlockMenus implements DragClient {
 			var newName:String = dialog.getField('Message Name');
 			if (newName.length == 0) return;
 			setBlockArg(newName);
-			app.runtime.clearAllReceiverCaches();
 		}
 		var d:DialogBox = new DialogBox(changeBroadcast);
 		d.addTitle('New Message');

--- a/src/scratch/ScratchSprite.as
+++ b/src/scratch/ScratchSprite.as
@@ -127,9 +127,18 @@ public class ScratchSprite extends ScratchObj {
 			// Clones share scripts and sounds with the original sprite.
 			scripts = spr.scripts;
 			sounds = spr.sounds;
+			// want to know which is the original sprite
+			if (spr.isClone) origSprite = spr.origSprite;
+			else origSprite = spr;
+			// will use caches from original sprite, since clone shares scripts
+			receiverCache = null;
+			edgeTriggeredCache = null;
+			keyPressedCache = null;
+			whenClickedCache = null;
 		} else {
 			for (i = 0; i < spr.scripts.length; i++) scripts.push(spr.scripts[i].duplicate(forClone));
 			sounds = spr.sounds.concat();
+			origSprite = null;  // should be already, right...?
 		}
 
 		// To support vector costumes, every sprite must have its own costume copies, even clones.


### PR DESCRIPTION
Hat blocks "when I receive"/"when backdrop switches", "when key pressed", "when this clicked" and "when /somesensor/" each now has its own cache for each original sprite. (Clones do not need a separate cache, since they share scripts with the original sprite. Collecting the relevant hat blocks for a clone just means effectively taking them from the original sprite.)
This avoids sweeping through all scripts of all sprites/clones/stage every time a key press/repeat happens, a broadcast is sent, or something is clicked. Also avoids the same sweep through all scripts of all sprites/clones/stage at every runtime step, looking for 'edge trigger' hat blocks.
Note that the cache for receivers is an Object which allows fast look-up of relevant receivers for a particular message.
