### PR TITLE
Saved 'host' extension property in project

### DIFF
--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -139,6 +139,7 @@ public class ExtensionManager {
 			descriptor.extensionName = ext.name;
 			descriptor.blockSpecs = ext.blockSpecs;
 			descriptor.menus = ext.menus;
+			if(ext.host) descriptor.host = ext.host;
 			if(ext.port) descriptor.extensionPort = ext.port;
 			else if(ext.javascriptURL) descriptor.javascriptURL = ext.javascriptURL;
 			result.push(descriptor);


### PR DESCRIPTION
The 'host' property is currently not saved in the extension section of the project, and it always defaults to '127.0.0.1' when a project is opened, even is the Scratch extension file (.s2e) has onther host defined.

Windows makes a distinction between 'localhost' and '127.0.0.1'. Hosting an http server on '127.0.0.1' is only allowed as an administrator. Hosting an http server on 'localhost' can be done as a regular user.

When building a Scratch http extension, hosting it on 'localhost' makes it easier to use. However, when a project is opened that contains an extension, the host will be reset to '127.0.0.1'. You need to reload the .s2e file to set the host to 'localhost'.

As far as I can see, saving the host property in the Scratch project file only has benefits.