### PR TITLE
3d cleanup

### DIFF
--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -451,6 +451,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 		if (childrenChanged) {// || effectsChanged) {
 			vertexData.position = 0;
 			childrenDrawn = 0;
+			setBlendFactors(true);
 			var skipped:uint = 0;
 			for (i = 0; i < numChildren; ++i) {
 				dispObj = scratchStage.getChildAt(i);
@@ -471,7 +472,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 	private var boundsDict:Dictionary = new Dictionary();
 	private var drawMatrix:Matrix3D = new Matrix3D();
 
-	private function drawChild(dispObj:DisplayObject, blend:Boolean = true):Boolean {
+	private function drawChild(dispObj:DisplayObject):Boolean {
 		const bounds:Rectangle = boundsDict[dispObj];
 		if (!bounds)
 			return false;
@@ -517,8 +518,6 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 		var componentIndex:int = calculateEffects(dispObj, bounds, rect, renderOpts, effects);
 
 		setEffectConstants(componentIndex);
-
-		setBlendFactors(blend);
 
 		drawTriangles();
 
@@ -1155,7 +1154,8 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 
 		__context.clear(0, 0, 0, 0);
 		__context.setScissorRectangle(new Rectangle(0, 0, bmd.width + 1, bmd.height + 1));
-		drawChild(dispObj, false);
+		setBlendFactors(false);
+		drawChild(dispObj);
 		__context.drawToBitmapData(bmd);
 
 		dispObj.x = oldX;

--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -1246,7 +1246,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 		//__context.addEventListener(Event.DEACTIVATE, onContextLoss);
 
 		__context.setDepthTest(false, Context3DCompareMode.ALWAYS);
-		__context.enableErrorChecking = true;
+		__context.enableErrorChecking = false;
 
 		// These are the standard blending factors for premultiplied alpha.
 		// This works for rendering both to bitmaps and the screen as long as the shader multiplies by alpha.

--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -471,7 +471,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 	private var boundsDict:Dictionary = new Dictionary();
 	private var drawMatrix:Matrix3D = new Matrix3D();
 
-	private function drawChild(dispObj:DisplayObject):Boolean {
+	private function drawChild(dispObj:DisplayObject, blend:Boolean = true):Boolean {
 		const bounds:Rectangle = boundsDict[dispObj];
 		if (!bounds)
 			return false;
@@ -517,6 +517,8 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 		var componentIndex:int = calculateEffects(dispObj, bounds, rect, renderOpts, effects);
 
 		setEffectConstants(componentIndex);
+
+		setBlendFactors(blend);
 
 		drawTriangles();
 
@@ -650,6 +652,17 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 		__context.setVertexBufferAt(0, vertexBuffer, 0, Context3DVertexBufferFormat.FLOAT_3);
 		// u, v
 		__context.setVertexBufferAt(1, vertexBuffer, 3, Context3DVertexBufferFormat.FLOAT_2);
+	}
+
+	private var currentBlendFactor:String;
+
+	private function setBlendFactors(blend:Boolean):void {
+		var newBlendFactor:String = blend ? Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA : Context3DBlendFactor.ZERO;
+		if (newBlendFactor == currentBlendFactor) return;
+
+		// Since we use pre-multiplied alpha, the source blend factor is always ONE
+		__context.setBlendFactors(Context3DBlendFactor.ONE, newBlendFactor);
+		currentBlendFactor = newBlendFactor;
 	}
 
 	private function drawTriangles():void {
@@ -1142,7 +1155,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 
 		__context.clear(0, 0, 0, 0);
 		__context.setScissorRectangle(new Rectangle(0, 0, bmd.width + 1, bmd.height + 1));
-		drawChild(dispObj);
+		drawChild(dispObj, false);
 		__context.drawToBitmapData(bmd);
 
 		dispObj.x = oldX;
@@ -1247,10 +1260,6 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 
 		__context.setDepthTest(false, Context3DCompareMode.ALWAYS);
 		__context.enableErrorChecking = false;
-
-		// These are the standard blending factors for premultiplied alpha.
-		// This works for rendering both to bitmaps and the screen as long as the shader multiplies by alpha.
-		__context.setBlendFactors(Context3DBlendFactor.ONE, Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA);
 
 		tlPoint = scratchStage.localToGlobal(originPt);
 	}
@@ -1391,6 +1400,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 		shaderCache = {};
 		currentShader = null;
 		currentTexture = null;
+		currentBlendFactor = null;
 
 		for (var i:int = 0; i < textures.length; ++i)
 			(textures[i] as ScratchTextureBitmap).disposeTexture();


### PR DESCRIPTION
I had removed the argument since pre-multiplied alpha lets us use the same blend mode for both stamps and normal drawing, making for simpler code. However, blending is cheaper when the destination factor is zero. With that in mind it may be a better idea to turn off blending when we can, especially on mobile platforms.
Also, disable error checking on Context3D. I left the line in there so it's easy to change it to `true` when debugging.