### PR TITLE
Added a method for setting default urls that can be overridden.

### DIFF
--- a/src/util/Server.as
+++ b/src/util/Server.as
@@ -48,6 +48,8 @@ public class Server implements IServer {
 	protected var URLs:Object = {};
 
 	public function Server() {
+		setDefaultURLs();
+
 		// Accept URL overrides from the flash variables
 		try {
 			var urlOverrides:String = Scratch.app.loaderInfo.parameters['urlOverrides'];
@@ -56,6 +58,9 @@ public class Server implements IServer {
 		catch (e:*) {
 		}
 	}
+
+	// No default URLs
+	protected function setDefaultURLs():void {}
 
 	public function overrideURLs(overrides:Object):void {
 		for (var name:String in overrides) {


### PR DESCRIPTION
Necessary to fix the online scratch version after merging ScratchX.