### PR TITLE
Bring back texture filtering workaround

### DIFF
--- a/src/render3d/shaders/fragment.agal
+++ b/src/render3d/shaders/fragment.agal
@@ -119,7 +119,7 @@ ft0.xyzw *= Tex_wh
 ft0.xy += Tex_u0v0
 
 // Get the texture pixel using ft0.xy as the coordinates
-ft1 = tex<2d,clamp,linear,nomip>(ft0, fs0)
+ft1 = tex<2d>(ft0, fs0)
 
 /*** ft1 == (r, g, b, a) ***/
 // Now de-multiply the color values that Flash pre-multiplied

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -559,13 +559,10 @@ public class ScratchStage extends ScratchObj {
 		commitPenStrokes(); // force any pen strokes to be rendered so they can be sensed
 
 		var bm1:BitmapData;
-		var mask:uint = 0xF0F8F8F0;
+		var mask:uint = 0x00F8F8F0;
 		if(Scratch.app.isIn3D) {
-			var b:Rectangle;
 			SCRATCH::allow3d {
-				b = s.currentCostume().bitmap ? s.img.getChildAt(0).getBounds(s) : s.getVisibleBounds(s);
 				bm1 = Scratch.app.render3D.getOtherRenderedChildren(s, 1);
-				//mask = 0x80F8F8F0;
 			}
 		}
 		else {


### PR DESCRIPTION
The recent 3D refactor broke the `forcePixelate` flag, which used to force the pixelate effect on under certain conditions. Using the "touching color _?" block with thin lines depended on this feature: linear filtering often causes the thin line to be blended too much with surrounding elements, resulting in failed detection.

This change is similar in spirit to the `forcePixelate` flag from before, but uses texture filtering instead of the pixelate effect. This should result in improved performance when the pixelate effect is not in use.

This fixes LLK/scratch-flash#836
