### PR TITLE
Apply video transparency as ghost effect

### DIFF
--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -818,7 +818,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 				scale = 1 / mosaic;
 			}
 		}
-		else if (dispObj is Bitmap) { // Remove else to allow graphics effects on video layer
+		if (dispObj is Bitmap) {
 			isNew = !bitmapsByID[id];
 			bitmapsByID[id] = (dispObj as Bitmap).bitmapData;
 			if (unrenderedChildren[dispObj] && textureIndexByID.hasOwnProperty(id)) {

--- a/src/scratch/ScratchStage.as
+++ b/src/scratch/ScratchStage.as
@@ -466,13 +466,21 @@ public class ScratchStage extends ScratchObj {
 			video.attachCamera(camera);
 			videoImage = new Bitmap(new BitmapData(video.width, video.height, false));
 			videoImage.alpha = videoAlpha;
+			SCRATCH::allow3d {
+				updateSpriteEffects(videoImage, {'ghost': 100 * (1 - videoAlpha)});
+			}
 			addChildAt(videoImage, getChildIndex(penLayer) + 1);
 		}
 	}
 
 	public function setVideoTransparency(transparency:Number):void {
 		videoAlpha = 1 - Math.max(0, Math.min(transparency / 100, 1));
-		if (videoImage) videoImage.alpha = videoAlpha;
+		if (videoImage) {
+			videoImage.alpha = videoAlpha;
+			SCRATCH::allow3d {
+				updateSpriteEffects(videoImage, {'ghost': transparency});
+			}
+		}
 	}
 
 	public function isVideoOn():Boolean { return videoImage != null }
@@ -546,11 +554,6 @@ public class ScratchStage extends ScratchObj {
 	SCRATCH::allow3d
 	public function updateSpriteEffects(spr:DisplayObject, effects:Object):void {
 		if(Scratch.app.isIn3D) {
-			if (videoImage && videoImage.alpha < 1) {
-				if (!effects) effects = {};
-				if (!effects.ghost) effects.ghost = BlockArg.epsilon;
-			}
-
 			Scratch.app.render3D.updateFilters(spr, effects);
 		}
 	}


### PR DESCRIPTION
The previous method of making the video image transparent relied on the fact that all objects were drawn with the same shader, and allowed the video image's alpha value to be used in place of the ghost effect. This broke when we started determining the shader on a per-object basis. Now video transparency is implemented by applying the standard ghost effect to the bitmap object representing the video image.

This fixes LLK/scratch-flash#837 and LLK/scratch-flash#838
See issues for test cases