### PR TITLE
Ensure correct appScale when activating 3D mode

### DIFF
--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -1263,7 +1263,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 			return;
 		}
 
-		setRenderView();
+		onStageResize();
 		//__context.addEventListener(Event.ACTIVATE, setupContext3D);
 		//__context.addEventListener(Event.DEACTIVATE, onContextLoss);
 


### PR DESCRIPTION
Instead of calling `setRenderView()` when setting up the 3D context, call `onStageResize()` which calls `setRenderView()` after calculating `appScale` and collecting the UI transform.

Test case: see issue #845