### PR TITLE
Improve framerate to 60fps instead of 30fps

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -166,7 +166,7 @@ public class Scratch extends Sprite {
 
 		stage.align = StageAlign.TOP_LEFT;
 		stage.scaleMode = StageScaleMode.NO_SCALE;
-		stage.frameRate = 30;
+		stage.frameRate = 60;
 		stage['color'] = CSS.backgroundColor(); // this setter doesn't exist on Air 2.6, so silently does nothing.
 
 		Block.setFonts(10, 9, true, 0); // default font sizes


### PR DESCRIPTION
It'll be nice if Scratch projects will run better in 60fps rather than the odd 30fps.