### PR TITLE
Show Load Experimental Extension only in dev mode

### DIFF
--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -149,9 +149,11 @@ public class PaletteBuilder {
 
 	protected function addExtensionButtons():void {
 		addAddExtensionButton();
-		var extensionDevManager:ExtensionDevManager = Scratch.app.extensionManager as ExtensionDevManager;
-		if (extensionDevManager) {
-			addItem(extensionDevManager.makeLoadExperimentalExtensionButton());
+		if (Scratch.app.isExtensionDevMode) {
+			var extensionDevManager:ExtensionDevManager = Scratch.app.extensionManager as ExtensionDevManager;
+			if (extensionDevManager) {
+				addItem(extensionDevManager.makeLoadExperimentalExtensionButton());
+			}
 		}
 	}
 


### PR DESCRIPTION
The button only works on ScratchX so it should be hidden elsewhere.
This fixes LLK/scratch-flash-online#186