### PR TITLE
Make sure the backbuffer isn't too small

### DIFF
--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -1149,7 +1149,7 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 		var changeBackBuffer:Boolean = isIOS || (bmd.width > scissorRect.width || bmd.height > scissorRect.height);
 		if (changeBackBuffer) {
 			projMatrix = createOrthographicProjectionMatrix(bmd.width, bmd.height, 0, 0);
-			__context.configureBackBuffer(bmd.width, bmd.height, 0, false);
+			__context.configureBackBuffer(Math.max(32, bmd.width), Math.max(32, bmd.height), 0, false);
 			pScale = 1;
 		}
 


### PR DESCRIPTION
Fixes an exception we're seeing.
http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display3D/Context3D.html#configureBackBuffer() - "The minimum size of the buffer is 32x32 pixels."