### PR TITLE
Correct build.properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,13 +1,11 @@
-#
 # To change properties, put overrides into a local.properties file!
-#
 
 # Flex SDK locations
-FLEX_HOME=/usr/local/lib/flex_sdk_4.11
+FLEX_HOME=/usr/local/lib/flex_sdk
 
 # Source locations for Scratch and the 3D rendering library
 SRC_DIR=${basedir}/src
-SRC_DIR_3D=${basedir}/3d_render_src
+SRC_DIR_3D=${basedir}/src/render3d
 
 # Where to find libraries to link into Scratch
 LIBS_DIR=${basedir}/libs


### PR DESCRIPTION
We forgot to change this file. We had the 3d render directory in ${basedir}/3d_render_src instead of ${basedir}/src/render3d - This changed file will be correct.
