### PR TITLE
Make stop button call ScratchExtensions.stop()

### DIFF
--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -436,13 +436,20 @@ public class ExtensionManager {
 					activeThread.firstTime = true;
 				}
 			}
-			else
+			else {
 				httpCall(ext, op, args);
+			}
 		} else {
-			if(op == 'reset_all') op = 'resetAll';
+			if (Scratch.app.jsEnabled) {
+				if (op == 'reset_all') {
+					app.externalCall('ScratchExtensions.stop', null, ext.name);
+				}
+				else {
+					// call a JavaScript extension function with the given arguments
+					app.externalCall('ScratchExtensions.runCommand', null, ext.name, op, args);
+				}
+			}
 
-			// call a JavaScript extension function with the given arguments
-			if(Scratch.app.jsEnabled) app.externalCall('ScratchExtensions.runCommand', null, ext.name, op, args);
 			app.interp.redraw(); // make sure interpreter doesn't do too many extension calls in one cycle
 		}
 	}


### PR DESCRIPTION
This change requires https://github.com/LLK/scratchr2/pull/2757

The `stop()` method is a new method that will allow ScratchExtensions to
decide whether to call the new `_stop()` method or the old `resetAll()`
method on a per-extension basis.