### PR TITLE
Set stage color only if supported

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -167,7 +167,11 @@ public class Scratch extends Sprite {
 		stage.align = StageAlign.TOP_LEFT;
 		stage.scaleMode = StageScaleMode.NO_SCALE;
 		stage.frameRate = 30;
-		stage['color'] = CSS.backgroundColor(); // this setter doesn't exist on Air 2.6, so silently does nothing.
+
+		if (stage.hasOwnProperty('color')) {
+			// Stage doesn't have a color property on Air 2.6, and Linux throws if you try to set it anyway.
+			stage['color'] = CSS.backgroundColor();
+		}
 
 		Block.setFonts(10, 9, true, 0); // default font sizes
 		Block.MenuHandlerFunction = BlockMenus.BlockMenuHandler;


### PR DESCRIPTION
We were setting the `color` property on the stage with the assumption that it would fail silently on versions of Flash which didn't support that feature. Unfortunately on Linux this throws an exception. This change checks for the property before trying to set it.
This fixes LLK/scratch-flash-offline#80