### PR TITLE
Change the way paint actions are committed on undo

### DIFF
--- a/src/svgeditor/BitmapEdit.as
+++ b/src/svgeditor/BitmapEdit.as
@@ -236,7 +236,7 @@ public class BitmapEdit extends ImageEdit {
 		imagesPart.setCanCrop(false);
 		highlightTool('none');
 		var obj:ISVGEditable = null;
-		if (newMode != toolMode && currentTool is SVGEditTool)
+		if ((bForce || newMode != toolMode) && currentTool is SVGEditTool)
 			obj = (currentTool as SVGEditTool).getObject();
 
 		var prevToolMode:String = toolMode;
@@ -409,6 +409,12 @@ public class BitmapEdit extends ImageEdit {
 	// -----------------------------
 	// Clear/Undo/Redo
 	//------------------------------
+
+	override protected function clearSelection():void {
+		// Re-activate the tool that (looks like) it's currently active
+		// If there's an uncommitted action, this will commit it in the same way that changing the tool would.
+		setToolMode(lastToolMode ? lastToolMode : toolMode, true);
+	}
 
 	public override function canClearCanvas():Boolean {
 		// True if canvas has any marks.

--- a/src/svgeditor/ImageEdit.as
+++ b/src/svgeditor/ImageEdit.as
@@ -824,18 +824,7 @@ package svgeditor {
 			}
 		}
 
-		private function clearSelection():void {
-			if (this is BitmapEdit) {
-				var ot:Boolean = currentTool as ObjectTransformer;
-				var tt:Boolean = currentTool is TextTool;
-				if (ot || tt) {
-					shutdown();
-					if (ot) {
-						targetCostume.undoList.pop(); // remove last entry (added by shutdown)
-						targetCostume.undoListIndex--;
-					}
-				}
-			}
+		protected function clearSelection():void {
 		}
 
 		protected final function recordForUndo(imgData:*, rotationCenterX:int, rotationCenterY:int):void {


### PR DESCRIPTION
On undo or redo, we now reactivate the tool that currently looks like
it's active. This means that pressing undo with an action in progress
commits that action just like changing a tool would, reducing the number
of code paths which commit an action. The old way was not working if the
undo button was pressed immediately after drawing an ellipse, a
rectangle, or some text.
This fixes #678
