### PR TITLE
Fixes #912 and #468, and is a suggestion for an improvement to PR #901.

### DIFF
--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -677,11 +677,11 @@ public class Interpreter {
 	// a reference to the Variable object is cached in the target object.
 
 	private function primVarGet(b:Block):* {
-		if (activeThread == null) return 0;
+		var target:ScratchObj = app.runtime.currentDoObj ? app.runtime.currentDoObj : activeThread.target;
 
-		var v:Variable = activeThread.target.varCache[b.spec];
+		var v:Variable = target.varCache[b.spec];
 		if (v == null) {
-			v = activeThread.target.varCache[b.spec] = activeThread.target.lookupOrCreateVar(b.spec);
+			v = target.varCache[b.spec] = target.lookupOrCreateVar(b.spec);
 			if (v == null) return 0;
 		}
 		// XXX: Do we need a get() for persistent variables here ?

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -51,6 +51,7 @@ public class ScratchRuntime {
 	public var lastAnswer:String = '';
 	public var cloneCount:int;
 	public var edgeTriggersEnabled:Boolean = false; // initially false, becomes true when project first run
+	public var currentDoObj:ScratchObj = null;
 
 	private var microphone:Microphone;
 	private var timerBase:uint;
@@ -333,7 +334,7 @@ public class ScratchRuntime {
 	private function processEdgeTriggeredHats():void {
 		if (!edgeTriggersEnabled) return;
 		activeHats = [];
-		allStacksAndOwnersDo(startEdgeTriggeredHats);
+		allStacksAndOwnersDo(startEdgeTriggeredHats,true);
 		triggeredHats = activeHats;
 	}
 
@@ -919,7 +920,7 @@ public class ScratchRuntime {
 		return result;
 	}
 
-	public function allStacksAndOwnersDo(f:Function):void {
+	public function allStacksAndOwnersDo(f:Function,setDoObj:Boolean=false):void {
 		// Call the given function on every stack in the project, passing the stack and owning sprite/stage.
 		// This method is used by broadcast, so enumerate sprites/stage from front to back to match Scratch.
 		var stage:ScratchStage = app.stagePane;
@@ -927,10 +928,13 @@ public class ScratchRuntime {
 		for (var i:int = stage.numChildren - 1; i >= 0; i--) {
 			var o:* = stage.getChildAt(i);
 			if (o is ScratchObj) {
+				if (setDoObj) currentDoObj = ScratchObj(o);
 				for each (stack in ScratchObj(o).scripts) f(stack, o);
 			}
 		}
+		if (setDoObj) currentDoObj = stage;
 		for each (stack in stage.scripts) f(stack, stage);
+		currentDoObj = null;
 	}
 
 	public function clearAllCaches():void {


### PR DESCRIPTION
It adds a new public var in ScratchRuntime.as, currentDoObj, which can be set during allStacksAndOwnersDo. Only processEdgeTriggeredHats uses it here (since that's causing #901 and #468, referencing a stack which is not the currentThread), but it can potentially be used if there are other such cases (for example, a hacked "when I receive" hat block will likely also run into the same bug).

It's probably not the most elegant thing, but it's straightforward, and it works.
Maybe someone has a better idea...?
