### PR TITLE
Fill off-stage areas with white for touch test

### DIFF
--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -447,7 +447,10 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 		if (textureDirty)
 			packTextureBitmaps();
 
-		__context.clear(0, 0, 0, 0);
+		// Generally the clear color will be replaced by the backdrop and/or pen layer.
+		// However, it will show when we render partially-off-stage regions for getOtherRenderedChildren().
+		// Filling these regions with white matches the behavior we get in 2D.
+		__context.clear(1, 1, 1, 1);
 
 		if (childrenChanged) {// || effectsChanged) {
 			vertexData.position = 0;


### PR DESCRIPTION
When in 2D, doing a `touching color` test while a sprite is partially off the stage tests against solid white. This change implements the same behavior in 3D, where previously the region would be transparent black.

This is a partial fix for #850.