### PR TITLE
Skip empty bitmap element Bitmap-to-Vector convert

### DIFF
--- a/src/ui/parts/ImagesPart.as
+++ b/src/ui/parts/ImagesPart.as
@@ -335,7 +335,10 @@ public class ImagesPart extends UIPart {
 		useBitmapEditor(false);
 
 		var svg:SVGElement = new SVGElement('svg');
-		svg.subElements.push(SVGElement.makeBitmapEl(c.baseLayerBitmap, 1 / c.bitmapResolution));
+		var nonTransparentBounds:Rectangle = c.baseLayerBitmap.getColorBoundsRect(0xFF000000, 0x00000000, false);
+		if (nonTransparentBounds.width != 0 && nonTransparentBounds.height != 0) {
+			svg.subElements.push(SVGElement.makeBitmapEl(c.baseLayerBitmap, 1 / c.bitmapResolution));
+		}
 		c.rotationCenterX /= c.bitmapResolution;
 		c.rotationCenterY /= c.bitmapResolution;
 		c.setSVGData(new SVGExport(svg).svgData(), false, false);


### PR DESCRIPTION
If we notice that all of the pixels of the bitmap are transparent then there's no need to add a bitmap element to the SVG.
This fixes #415