### PR TITLE
Fix the way jsThrowError logs its message

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -441,7 +441,7 @@ public class Scratch extends Sprite {
 	public function jsThrowError(s:String):void {
 		// Throw the given string as an error in the browser. Errors on the production site are logged.
 		var errorString:String = 'SWF Error: ' + s;
-		logMessage(LogLevel.ERROR, errorString);
+		log(LogLevel.ERROR, errorString);
 		if (jsEnabled) {
 			externalCall('JSthrowError', null, errorString);
 		}


### PR DESCRIPTION
This was using the wrong call and causing these errors to be logged as `err` with the actual message stored in the `extraData` field.

This fixes LLK/scratch-flash-online#211