### PR TITLE
Check length before magic on sprite/costume upload

### DIFF
--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -565,10 +565,7 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 			uploadCostume(costumeOrSprite as ScratchCostume, uploadComplete);
 		} else {
 			data.position = 0;
-			if (data.readUTFBytes(4) != 'ObjS') {
-				data.position = 0;
-				new ProjectIO(app).decodeSpriteFromZipFile(data, spriteDecoded, spriteError);
-			} else {
+			if (data.bytesAvailable > 4 && data.readUTFBytes(4) == 'ObjS') {
 				var info:Object;
 				var objTable:Array;
 				data.position = 0;
@@ -586,6 +583,9 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 					return;
 				}
 				new ProjectIO(app).decodeAllImages(newProject.allObjects(), imagesDecoded, spriteError);
+			} else {
+				data.position = 0;
+				new ProjectIO(app).decodeSpriteFromZipFile(data, spriteDecoded, spriteError);
 			}
 		}
 	}


### PR DESCRIPTION
This avoids throwing an exception when attempting to read a very short file, such as a zero-byte file.
This fixes LLK/scratch-flash-online#102