### PR TITLE
Make two more strings available for translation

### DIFF
--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -157,7 +157,7 @@ public class BlockMenus implements DragClient {
 		// translated. This mechanism prevents translating proper names such as sprite,
 		// costume, or variable names.
 		function isGeneric(s:String):Boolean {
-			return ['duplicate', 'delete', 'add comment'].indexOf(s) > -1;
+			return ['duplicate', 'delete', 'add comment', 'clean up'].indexOf(s) > -1;
 		}
 		switch (menuName) {
 		case 'attribute':

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -57,7 +57,7 @@ public class PaletteBuilder {
 			'Stage selected:', 'No motion blocks',
 			'Make a Block', 'Make a List', 'Make a Variable',
 			'New List', 'List name', 'New Variable', 'Variable name',
-			'New Block', 'Add an Extension'];
+			'New Block', 'Add an Extension', 'when Stage clicked'];
 	}
 
 	public function showBlocksForCategory(selectedCategory:int, scrollToOrigin:Boolean, shiftKey:Boolean = false):void {


### PR DESCRIPTION
The 'clean up' and 'when Stage clicked' strings are now available for translation.
This fixes LLK/scratchr2#2785