### PR TITLE
Add strings() method to ScriptsPane

### DIFF
--- a/src/translation/TranslatableStrings.as
+++ b/src/translation/TranslatableStrings.as
@@ -117,6 +117,7 @@ public class TranslatableStrings {
 		addAll(ProjectIO.strings());
 		// Get the strings from the Scratch app instance so that the offline version can add strings
 		addAll(Scratch.app.strings());
+		addAll(ScriptsPane.strings());
 		addAll(SoundEditor.strings());
 		addAll(SoundsPart.strings());
 		addAll(SpriteInfoPart.strings());

--- a/src/uiwidgets/ScriptsPane.as
+++ b/src/uiwidgets/ScriptsPane.as
@@ -59,6 +59,13 @@ public class ScriptsPane extends ScrollFrameContents {
 		addFeedbackShape();
 	}
 
+	public static function strings():Array {
+		return [
+			'add comment',
+			'clean up'
+		];
+	}
+
 	private function createTexture():void {
 		const alpha:int = 0x90 << 24;
 		const bgColor:int = alpha | 0xD7D7D7;


### PR DESCRIPTION
The 'clean up' string was not being included in the editor exports, so
I've added it here explicitly. The 'add a comment' string was already
included in the editor exports, but I can't figure out why... it seems
best to properly include it here as well.