### PR TITLE
Open internal extension tips with 'ext:' tag

### DIFF
--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -372,8 +372,12 @@ public class PaletteBuilder {
 
 	protected function getExtensionMenu(ext:ScratchExtension):Menu {
 		function showAbout():void {
-			// Open in the tips window if the URL starts with /info/ and another tab otherwise
-			if (ext.url) {
+			if (ext.isInternal) {
+				// Internal extensions are handled specially by tip-bar.js
+				app.showTip('ext:' + ext.name);
+			}
+			else if (ext.url) {
+				// Open in the tips window if the URL starts with /info/ and another tab otherwise
 				if (ext.url.indexOf('/info/') === 0) app.showTip(ext.url);
 				else if (ext.url.indexOf('http') === 0) navigateToURL(new URLRequest(ext.url));
 				else DialogBox.notify('Extensions', 'Unable to load about page: the URL given for extension "' + ext.name + '" is not formatted correctly.');


### PR DESCRIPTION
Internal extensions have special tips content formatted for the built-in tips window. These pages are accessed by passing a specially formatted tag to the tips API in JavaScript -- for example 'ext:LEGO WeDo' for the WeDo extension. This change makes the editor supply that sort of tag when opening tips for an internal extension. The behavior is unchanged for non-internal extensions.

This fixes LLK/scratchr2#2709, assuming the tag -> URL mapping is correct on the JavaScript side of the tips system.

Testing notes:
This change alters the way tips are loaded for internal extensions in general, so please test tips for both WeDo and PicoBoard.