### PR TITLE
Improve logging, especially for translation errors

### DIFF
--- a/src/logging/Log.as
+++ b/src/logging/Log.as
@@ -63,14 +63,23 @@ public class Log {
 			return entryString || (entryString = entry.toString());
 		}
 
+		var extraString:String;
+		function getExtraString():String {
+			return extraString || (extraString = util.JSON.stringify(extraData));
+		}
+
 		if (Capabilities.isDebugger) {
 			trace(getEntryString());
 		}
-		if (Scratch.app.jsEnabled && echoToJS) {
-			Scratch.app.externalCall('console.log', null, getEntryString());
-		}
-		if (LogLevel.TRACK == severity && Scratch.app.jsEnabled) {
-			Scratch.app.externalCall('JStrackEvent', null, messageKey, extraData ? util.JSON.stringify(extraData) : null);
+		if (Scratch.app.jsEnabled) {
+			if (echoToJS) {
+				Scratch.app.externalCall(
+						'console.log', null, getEntryString() + (extraData ? '\n' + getExtraString() : ''));
+			}
+			if (LogLevel.TRACK == severity) {
+				Scratch.app.externalCall(
+						'JStrackEvent', null, messageKey, extraData ? getExtraString() : null);
+			}
 		}
 		return entry;
 	}

--- a/src/translation/Translator.as
+++ b/src/translation/Translator.as
@@ -65,8 +65,8 @@ public class Translator {
 		function gotPOFile(data:ByteArray):void {
 			if (data) {
 				dictionary = parsePOData(data);
+				setFontsFor(lang); // also sets currentLang
 				checkBlockTranslations();
-				setFontsFor(lang);
 			}
 			Scratch.app.translationChanged();
 		}
@@ -81,7 +81,7 @@ public class Translator {
 	public static function setLanguage(lang:String):void {
 		if ('import translation file' == lang) { importTranslationFromFile(); return; }
 		if ('set font size' == lang) { fontSizeMenu(); return; }
-		
+
 		setLanguageValue(lang);
 		Scratch.app.server.setSelectedLang(lang);
 	}
@@ -225,7 +225,9 @@ public class Translator {
 		var translatedSpec:String = map(spec);
 		if (translatedSpec == spec) return; // not translated
 		if (!argsMatch(extractArgs(spec), extractArgs(translatedSpec))) {
-			Scratch.app.log(LogLevel.WARNING, 'Block argument mismatch', {spec: spec, translated: translatedSpec});
+			Scratch.app.log(
+					LogLevel.WARNING, 'Block argument mismatch',
+					{language: currentLang, spec: spec, translated: translatedSpec});
 			delete dictionary[spec]; // remove broken entry from dictionary
 		}
 	}


### PR DESCRIPTION
Logging events forwarded to the JS console now include extradata.
The `currentLang` is set in Translator.as before checking for translation problems instead of after.
When a warning is logged due to a block argument mismatch, the current language is included in the event.