### PR TITLE
Log `jsThrowError()` as a warning

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -441,7 +441,7 @@ public class Scratch extends Sprite {
 	public function jsThrowError(s:String):void {
 		// Throw the given string as an error in the browser. Errors on the production site are logged.
 		var errorString:String = 'SWF Error: ' + s;
-		log(LogLevel.ERROR, errorString);
+		log(LogLevel.WARNING, errorString);
 		if (jsEnabled) {
 			externalCall('JSthrowError', null, errorString);
 		}


### PR DESCRIPTION
We're getting a lot of error events from this, especially for "Calling JSeditorReady() failed." Changing these messages to warnings will prevent us from getting error events for what looks like a symptom rather than the actual cause. The warnings will still appear in the log for an error that happens afterward.