### PR TITLE
Make JS log events richer; improve callServer logs

### DIFF
--- a/src/logging/Log.as
+++ b/src/logging/Log.as
@@ -65,7 +65,14 @@ public class Log {
 
 		var extraString:String;
 		function getExtraString():String {
-			return extraString || (extraString = util.JSON.stringify(extraData));
+			if (!extraString) {
+				try {
+					extraString = util.JSON.stringify(extraData);
+				} catch (e:*) {
+					extraString = '<extraData stringify failed>';
+				}
+			}
+			return extraString;
 		}
 
 		if (Capabilities.isDebugger) {
@@ -73,12 +80,15 @@ public class Log {
 		}
 		if (Scratch.app.jsEnabled) {
 			if (echoToJS) {
-				Scratch.app.externalCall(
-						'console.log', null, getEntryString() + (extraData ? '\n' + getExtraString() : ''));
+				if (extraData) {
+					Scratch.app.externalCall('console.log', null, getEntryString(), extraData);
+				}
+				else {
+					Scratch.app.externalCall('console.log', null, getEntryString());
+				}
 			}
 			if (LogLevel.TRACK == severity) {
-				Scratch.app.externalCall(
-						'JStrackEvent', null, messageKey, extraData ? getExtraString() : null);
+				Scratch.app.externalCall('JStrackEvent', null, messageKey, extraData ? getExtraString() : null);
 			}
 		}
 		return entry;

--- a/src/util/JSON.as
+++ b/src/util/JSON.as
@@ -277,6 +277,7 @@ public class JSON {
 		if (value is Number) buf += isFinite(value) ? value : '0';
 		else if (value is Boolean) buf += value;
 		else if (value is String) buf += '"' + encodeString(value) + '"';
+		else if (value is ByteArray) buf += '"' + encodeString(value.toString()) + '"';
 		else if (value == null) buf += "null";
 		else if (value is Array) writeArray(value);
 		else if (value is BitmapData) buf += "null"; // bitmaps sometimes appear in old project info objects

--- a/src/util/Server.as
+++ b/src/util/Server.as
@@ -127,24 +127,15 @@ public class Server implements IServer {
 	// This will be called if callServer encounters an error, before whenDone(null) is called.
 	// The url and data parameters match those passed to callServer.
 	protected function onCallServerError(url:String, data:*, event:ErrorEvent):void {
-//			if(err.type != IOErrorEvent.IO_ERROR || url.indexOf('/backpack/') == -1) {
-//				if(data)
-//					Scratch.app.logMessage('Failed server request for '+url+' with data ['+data+']');
-//				else
-//					Scratch.app.logMessage('Failed server request for '+url);
-//			}
+		// Don't send this as an error since it seems to saturate our logging backend.
+		Scratch.app.log(LogLevel.WARNING, 'Failed server request', {event: event, url: url, data: data});
 		// We shouldn't have SecurityErrorEvents unless the crossdomain file failed to load
 		// Re-trying here should help project save failures but we'll need to add more code to re-try loading projects
 		if (event is SecurityErrorEvent) {
 			var urlPathStart:int = url.indexOf('/', 10);
 			var policyFileURL:String = url.substr(0, urlPathStart) + '/crossdomain.xml?cb=' + Math.random();
 			Security.loadPolicyFile(policyFileURL);
-			Scratch.app.log(LogLevel.WARNING, 'Reloading policy file', {url: policyFileURL});
-		}
-		if (data || url.indexOf('/set/') > -1) {
-			// TEMPORARY HOTFIX: Don't send this message since it seems to saturate our logging backend.
-			//Scratch.app.logMessage('Failed server request for '+url+' with data ['+data+']');
-			trace('Failed server request for ' + url + ' with data [' + data + ']');
+			Scratch.app.log(LogLevel.WARNING, 'Reloading policy file', {policy: policyFileURL, initiator: url});
 		}
 	}
 


### PR DESCRIPTION
- Logging events echoed to JS now have their `extraData` sent over
  intact, so that the objects can be inspected in the JS debugger.
- JSON stringification of event `extraData` is protected with a
  try/catch, in case some non-stringifiable data sneaks in. If
  stringification throws the `extraData` will be replaced with a string
  indicating such.
- JSON stringification has been extended to handle `ByteArray` as if it
  were a string. This probably isn't useful except for logging, but it
  does prevent an exception from being thrown.
- The logging for `callServer` has been simplified and uncommented. It
  had originally been commented out in order to avoid overloading our
  event tracking system. That's still a concern, but now it can be
  logged as a warning: it won't generate a tracking event, but it will
  show up in the logging history if a critical error happens afterward.
  It will also show up in the JS console.

Test cases:
- There should be no noticeable change in the editor.
- At least some of the events logged to the JS console should now allow inspection as JS objects. Exact behavior depends on the browser.
- The string part of an event (time stamp, log level, general description) should always be visible even when the `extraData` object is not expanded.