### PR TITLE
Removing ask prompt when its thread gets stopped, and fixing ask click-through, and ask-bubble outline (fixes #235, #600 and #484)

### DIFF
--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -177,6 +177,7 @@ public class Interpreter {
 				if (t.tmpObj is ScratchSoundPlayer) {
 					(t.tmpObj as ScratchSoundPlayer).stopPlaying();
 				}
+				if (askThread == t) app.runtime.clearAskPrompts();
 				t.stop();
 			}
 		}
@@ -206,6 +207,7 @@ public class Interpreter {
 	public function stopAllThreads():void {
 		threads = [];
 		if (activeThread != null) activeThread.stop();
+		app.runtime.clearAskPrompts(); // seems sensible this should happen here
 		clearWarpBlock();
 		app.runtime.clearRunFeedback();
 		doRedraw = true;

--- a/src/primitives/Primitives.as
+++ b/src/primitives/Primitives.as
@@ -199,7 +199,10 @@ public class Primitives {
 	private function primDeleteClone(b:Block):void {
 		var clone:ScratchSprite = interp.targetSprite();
 		if ((clone == null) || (!clone.isClone) || (clone.parent == null)) return;
-		if (clone.bubble && clone.bubble.parent) clone.bubble.parent.removeChild(clone.bubble);
+		if (clone.bubble && clone.bubble.parent) {
+			clone.bubble.parent.removeChild(clone.bubble);
+			clone.bubble = null; // prevent potential exception inside hideAskBubble (via clearAskPrompts in stopThreadsFor below)
+		}
 		clone.parent.removeChild(clone);
 		app.interp.stopThreadsFor(clone);
 		app.runtime.cloneCount--;

--- a/src/primitives/SensingPrims.as
+++ b/src/primitives/SensingPrims.as
@@ -208,7 +208,7 @@ public class SensingPrims {
 		if (interp.activeThread.firstTime) {
 			var question:String = interp.arg(b, 0);
 			if ((obj is ScratchSprite) && (obj.visible)) {
-				ScratchSprite(obj).showBubble(question, 'talk', true);
+				ScratchSprite(obj).showBubble(question, 'talk', obj, true);
 				app.runtime.showAskPrompt('');
 			} else {
 				app.runtime.showAskPrompt(question);

--- a/src/scratch/AskPrompter.as
+++ b/src/scratch/AskPrompter.as
@@ -55,7 +55,10 @@ public class AskPrompter extends Sprite {
 	public function answer():String { return input.text; }
 
 	private function mouseDown(evt:MouseEvent):void {
-		if (doneButton.hitTestPoint(evt.stageX, evt.stageY)) app.runtime.hideAskPrompt(this);
+		if (doneButton.hitTestPoint(evt.stageX, evt.stageY)) {
+			app.runtime.hideAskPrompt(this);
+			evt.stopImmediatePropagation(); // stop click going through
+		}
 	}
 
 	private function keyDown(evt:KeyboardEvent):void {

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -493,7 +493,16 @@ public class ScratchRuntime {
 		setTimeout(p.grabKeyboardFocus, 100); // workaround for Window keyboard event handling
 	}
 
+	private function hideAskBubble():void {
+		if (interp.askThread && interp.askThread.target) {
+			if (interp.askThread.target!=app.stagePane && interp.askThread.target.bubble) {
+				if (interp.askThread.target.bubble.style=='ask') interp.askThread.target.hideBubble();
+			}
+		}
+	}
+
 	public function hideAskPrompt(p:AskPrompter):void {
+		hideAskBubble();
 		interp.askThread = null;
 		lastAnswer = p.answer();
 		if (p.parent) {
@@ -512,6 +521,7 @@ public class ScratchRuntime {
 	}
 
 	public function clearAskPrompts():void {
+		hideAskBubble();
 		interp.askThread = null;
 		var allPrompts:Array = [];
 		var uiLayer:Sprite = app.stagePane.getUILayer();

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -136,7 +136,7 @@ public class ScratchRuntime {
 
 //----------
 	public function stopAll():void {
-		interp.stopAllThreads();
+		interp.stopAllThreads();  // this does clearAskPrompts now
 		clearRunFeedback();
 		app.stagePane.deleteClones();
 		cloneCount = 0;
@@ -148,7 +148,6 @@ public class ScratchRuntime {
 			s.clearFilters();
 			s.hideBubble();
 		}
-		clearAskPrompts();
 		app.removeLoadProgressBox();
 		motionDetector = null;
 	}

--- a/src/scratch/TalkBubble.as
+++ b/src/scratch/TalkBubble.as
@@ -24,9 +24,9 @@ package scratch {
 public class TalkBubble extends Sprite {
 
 	public var pointsLeft:Boolean;
+	public var style:String; // 'say' or 'ask' or 'result'
 
 	private var type:String; // 'say' or 'think'
-	private var style:String; // 'say' or 'ask' or 'result'
 	private var shape:Shape;
 	private var text:TextField;
 	private var source:Object;


### PR DESCRIPTION
Remove ask prompter when clone showing it gets deleted, and when "stop other scripts in sprite/stage" stops the thread that it's running in.

Also, it seems sensible to me that Interpreter.stopAllThreads should remove ask prompts if anything else besides ScratchRuntime.stopAll ever uses it (so ScratchRuntime.stopAll no longer needs to explicitly clearAskPrompts itself).

Fixes #235. (Later commits also fix #600 and #484.)
