### PR TITLE
Fix non-refresh "stop this script" issue #475

### DIFF
--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -665,8 +665,9 @@ public class Interpreter {
 
 	private function primReturn(b:Block):void {
 		// Return from the innermost procedure. If not in a procedure, stop the thread.
-		var didReturn:Boolean = activeThread.returnFromProcedure();
-		if (!didReturn) {
+		if (activeThread.wantReturnFromProcedure()) {
+			activeThread.block = null;  // script will return 'naturally'
+		} else {
 			activeThread.stop();
 			yield = true;
 		}

--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -272,7 +272,6 @@ public class Interpreter {
 
 			while (activeThread.block == null) { // end of block sequence
 				if (!activeThread.popState()) return; // end of script
-				if (activeThread.block == null) continue;  // can end up null if procedure did "stop this script"
 				if ((activeThread.block == warpBlock) && activeThread.firstTime) { // end of outer warp block
 					clearWarpBlock();
 					activeThread.block = activeThread.block.nextBlock;
@@ -666,9 +665,7 @@ public class Interpreter {
 
 	private function primReturn(b:Block):void {
 		// Return from the innermost procedure. If not in a procedure, stop the thread.
-		if (activeThread.wantReturnFromProcedure()) {
-			activeThread.block = null;  // script will return 'naturally'
-		} else {
+		if (!activeThread.returnFromProcedure()) {
 			activeThread.stop();
 			yield = true;
 		}

--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -272,6 +272,7 @@ public class Interpreter {
 
 			while (activeThread.block == null) { // end of block sequence
 				if (!activeThread.popState()) return; // end of script
+				if (activeThread.block == null) continue;  // can end up null if procedure did "stop this script"
 				if ((activeThread.block == warpBlock) && activeThread.firstTime) { // end of outer warp block
 					clearWarpBlock();
 					activeThread.block = activeThread.block.nextBlock;

--- a/src/interpreter/Thread.as
+++ b/src/interpreter/Thread.as
@@ -108,11 +108,11 @@ public class Thread {
 		return false;
 	}
 
-	public function wantReturnFromProcedure():Boolean {
+	public function returnFromProcedure():Boolean {
 		for (var i:int = sp - 1; i >= 0; i--) {
 			if (stack[i].block.op == Specs.CALL) {
-				// nullify all blocks up to caller, so they end through usual mechanism
-				while (i<sp-1) stack[++i].block = null;
+				sp = i + 1;  // 'hack' the stack pointer, but don't do the final popState here
+				block = null;  // make it do the final popState through the usual stepActiveThread mechanism
 				return true;
 			}
 		}

--- a/src/interpreter/Thread.as
+++ b/src/interpreter/Thread.as
@@ -110,7 +110,11 @@ public class Thread {
 
 	public function wantReturnFromProcedure():Boolean {
 		for (var i:int = sp - 1; i >= 0; i--) {
-			if (stack[i].block.op == Specs.CALL) return true;  // let it just return by itself
+			if (stack[i].block.op == Specs.CALL) {
+				// nullify all blocks up to caller, so they end through usual mechanism
+				while (i<sp-1) stack[++i].block = null;
+				return true;
+			}
 		}
 		return false;
 	}

--- a/src/interpreter/Thread.as
+++ b/src/interpreter/Thread.as
@@ -108,13 +108,9 @@ public class Thread {
 		return false;
 	}
 
-	public function returnFromProcedure():Boolean {
+	public function wantReturnFromProcedure():Boolean {
 		for (var i:int = sp - 1; i >= 0; i--) {
-			if (stack[i].block.op == Specs.CALL) {
-				sp = i + 1;
-				popState();
-				return true;
-			}
+			if (stack[i].block.op == Specs.CALL) return true;  // let it just return by itself
 		}
 		return false;
 	}


### PR DESCRIPTION
[NOTE: description below no longer applies to the way it works in the final commit - see latest code notes and comments instead...]

Instead of trying to set the StackFrame pointer (var sp in Thread.as) to go straight back to the caller (in returnFromProcedure in Thread.as), this nullifies each block in the StackFrame 'chain' up to the caller, and sets the activeThread's block to null.

This means it uses the 'standard' mechanism in stepActiveThread to go back through the StackFrame chain, because it just thinks all of the stacks before the caller have naturally reached their final blocks.

Fixes #475
