### PR TITLE
Fix #966 by using currentDoObj in Interpreter.targetObj() & targetSprite()

### DIFF
--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -93,8 +93,8 @@ public class Interpreter {
 //		checkPrims();
 	}
 
-	public function targetObj():ScratchObj { return ScratchObj(activeThread.target) }
-	public function targetSprite():ScratchSprite { return activeThread.target as ScratchSprite }
+	public function targetObj():ScratchObj { return app.runtime.currentDoObj ? app.runtime.currentDoObj : activeThread.target }
+	public function targetSprite():ScratchSprite { return (app.runtime.currentDoObj ? app.runtime.currentDoObj : activeThread.target) as ScratchSprite }
 
 	/* Threads */
 


### PR DESCRIPTION
This fix means currentDoObj gets used for numerous other primitives that can also have their blocks end up in a hat block (where activeThread is invalid) - just as primVarGet uses currentDoObj in #913 to fix #912 & #468.

For a demo of the bug, see https://scratch.mit.edu/projects/90835029/
