### PR TITLE
Magic wand didn't handle transitions well

### DIFF
--- a/src/svgeditor/BitmapEdit.as
+++ b/src/svgeditor/BitmapEdit.as
@@ -247,7 +247,9 @@ public class BitmapEdit extends ImageEdit {
 				// User was editing an object and switched tools, bake the object
 				bakeIntoBitmap();
 				saveToCostume();
-				targetCostume.segmentationState.unmarkedBitmap = workArea.getBitmap().bitmapData.clone();
+				if(segmentationTool){
+					segmentationTool.refresh();
+				}
 			}
 		}
 	}
@@ -372,6 +374,9 @@ public class BitmapEdit extends ImageEdit {
 		newBM.draw(oldBM, m);
 		workArea.getBitmap().bitmapData = newBM;
 		saveToCostume();
+		if(segmentationTool){
+			segmentationTool.refresh();
+		}
 	}
 
 	private function getBitmapSelection():SVGBitmap {

--- a/src/svgeditor/BitmapEdit.as
+++ b/src/svgeditor/BitmapEdit.as
@@ -247,6 +247,7 @@ public class BitmapEdit extends ImageEdit {
 				// User was editing an object and switched tools, bake the object
 				bakeIntoBitmap();
 				saveToCostume();
+				targetCostume.segmentationState.unmarkedBitmap = workArea.getBitmap().bitmapData.clone();
 			}
 		}
 	}

--- a/src/svgeditor/BitmapEdit.as
+++ b/src/svgeditor/BitmapEdit.as
@@ -189,9 +189,10 @@ public class BitmapEdit extends ImageEdit {
 		sel.redraw();
 		sel.x = destP.x - c.width() / 2;
 		sel.y = destP.y - c.height() / 2;
-		workArea.getContentLayer().addChild(sel);
 
 		setToolMode('bitmapSelect');
+		workArea.getContentLayer().addChild(sel);
+
 		(currentTool as ObjectTransformer).select(new Selection([sel]));
 	}
 
@@ -360,7 +361,19 @@ public class BitmapEdit extends ImageEdit {
 	}
 
 	protected override function flipAll(vertical:Boolean):void {
-		var oldBM:BitmapData = workArea.getBitmap().bitmapData;
+		workArea.getBitmap().bitmapData = flipBitmap(vertical, workArea.getBitmap().bitmapData);
+		if(segmentationTool && targetCostume.segmentationState.lastMask){
+			targetCostume.segmentationState.recordForUndo();
+			targetCostume.nextSegmentationState();
+			targetCostume.segmentationState.flip(vertical);
+			segmentationTool.refreshSegmentation();
+		}
+		else{
+			saveToCostume();
+		}
+	}
+
+	public static function flipBitmap(vertical:Boolean, oldBM:BitmapData):BitmapData{
 		var newBM:BitmapData = new BitmapData(oldBM.width, oldBM.height, true, 0);
 		var m:Matrix = new Matrix();
 		if (vertical) {
@@ -372,11 +385,7 @@ public class BitmapEdit extends ImageEdit {
 			m.translate(oldBM.width, 0);
 		}
 		newBM.draw(oldBM, m);
-		workArea.getBitmap().bitmapData = newBM;
-		saveToCostume();
-		if(segmentationTool){
-			segmentationTool.refresh();
-		}
+		return newBM;
 	}
 
 	private function getBitmapSelection():SVGBitmap {
@@ -416,7 +425,9 @@ public class BitmapEdit extends ImageEdit {
 	override protected function clearSelection():void {
 		// Re-activate the tool that (looks like) it's currently active
 		// If there's an uncommitted action, this will commit it in the same way that changing the tool would.
-		setToolMode(lastToolMode ? lastToolMode : toolMode, true);
+		if(!segmentationTool){
+			setToolMode(lastToolMode ? lastToolMode : toolMode, true);
+		}
 	}
 
 	public override function canClearCanvas():Boolean {

--- a/src/svgeditor/ImageEdit.as
+++ b/src/svgeditor/ImageEdit.as
@@ -64,7 +64,7 @@ public class ImageEdit extends Sprite {
 	private var svgEditorMask:Shape;
 	private var currentCursor:String;
 
-	private function get segmentationTool():BitmapBackgroundTool {
+	protected function get segmentationTool():BitmapBackgroundTool {
 		return currentTool as BitmapBackgroundTool;
 	}
 

--- a/src/svgeditor/ImageEdit.as
+++ b/src/svgeditor/ImageEdit.as
@@ -586,7 +586,6 @@ public class ImageEdit extends Sprite {
 		var toolChanged:Boolean = true;//!currentTool || (immediateTools.indexOf(newMode) == -1);
 		var s:Selection = null;
 		if (currentTool) {
-			var tool:BitmapBackgroundTool = segmentationTool;
 			if (toolMode == 'select' && newMode != 'select')
 				s = (currentTool as ObjectTransformer).getSelection();
 

--- a/src/svgeditor/objs/SegmentationState.as
+++ b/src/svgeditor/objs/SegmentationState.as
@@ -5,6 +5,8 @@ package svgeditor.objs {
 import flash.display.BitmapData;
 import flash.geom.Rectangle;
 
+import svgeditor.BitmapEdit;
+
 public class SegmentationState {
 	public var scribbleBitmap:BitmapData;
 	public var unmarkedBitmap:BitmapData;
@@ -62,6 +64,7 @@ public class SegmentationState {
 	public function reset():void{
 		scribbleBitmap = null;
 		lastMask = null;
+		next = null;
         xMin = -1;
         yMin = -1;
         xMax = 0;
@@ -72,5 +75,12 @@ public class SegmentationState {
 		prev = next = null;
 	}
 
+	public function flip(vertical:Boolean):void{
+		scribbleBitmap = BitmapEdit.flipBitmap(vertical, scribbleBitmap);
+		lastMask = BitmapEdit.flipBitmap(vertical, lastMask);
+		unmarkedBitmap = BitmapEdit.flipBitmap(vertical, unmarkedBitmap);
+		costumeRect.x = unmarkedBitmap.width - costumeRect.x - costumeRect.width;
+		costumeRect.y = unmarkedBitmap.height - costumeRect.y - costumeRect.height;
+	}
 }
 }

--- a/src/svgeditor/tools/BitmapBackgroundTool.as
+++ b/src/svgeditor/tools/BitmapBackgroundTool.as
@@ -126,6 +126,11 @@ public class BitmapBackgroundTool extends BitmapPencilTool{
 		super.init();
 	}
 
+	public override function refresh():void{
+		segmentationState.unmarkedBitmap = bitmapLayerData.clone();
+		segmentationState.costumeRect = bitmapLayerData.getColorBoundsRect(0xFF000000, 0x0, false)
+	}
+
 
     protected override function shutdown():void{
 		if(segmentationState != initialState)


### PR DESCRIPTION
```
-When leaving bitmapSelect, the work area was not update until after
creating of the new tool
-Magic wand would then use an old copy of the work area
-Added line to update this copy of the work area when this
transition occurs
```
