### PR TITLE
Hiding ColorPicker where appropriate

### DIFF
--- a/src/svgeditor/BitmapEdit.as
+++ b/src/svgeditor/BitmapEdit.as
@@ -67,10 +67,10 @@ public class BitmapEdit extends ImageEdit {
 
 	protected override function getToolDefs():Array { return bitmapTools }
 
-	protected override function onColorChange(e:Event):void {
+	protected override function onDrawPropsChange(e:Event):void {
 		var pencilTool:BitmapPencilTool = currentTool as BitmapPencilTool;
 		if (pencilTool) pencilTool.updateProperties();
-		super.onColorChange(e);
+		super.onDrawPropsChange(e);
 	}
 
 	public override function shutdown():void {

--- a/src/svgeditor/ColorPicker.as
+++ b/src/svgeditor/ColorPicker.as
@@ -120,7 +120,7 @@ public class ColorPicker extends Sprite {
 			var tmp:int = props.rawColor;
 			props.rawColor = props.rawSecondColor;
 			props.rawSecondColor = tmp;
-			drawPropsUI.sendChangeEvent();
+			drawPropsUI.onColorChange();
 			updateSwatches();
 		}
 		primaryColorSwatch = new Sprite();
@@ -227,7 +227,7 @@ public class ColorPicker extends Sprite {
 			alpha = 0;
 		}
 		setCurrentColor(color, alpha);
-		drawPropsUI.sendChangeEvent();
+		drawPropsUI.onColorChange();
 		//pickWheelColor();
 	}
 
@@ -302,7 +302,7 @@ public class ColorPicker extends Sprite {
 				m.translate(-pos.x, -pos.y);
 				b.draw(hsvColorPicker, m);
 				setCurrentColor(b.getPixel32(0, 0), 1, false);
-				drawPropsUI.sendChangeEvent();
+				drawPropsUI.onColorChange();
 			}
 		}
 	}

--- a/src/svgeditor/DrawPropertyUI.as
+++ b/src/svgeditor/DrawPropertyUI.as
@@ -38,6 +38,7 @@ import uiwidgets.*;
 public class DrawPropertyUI extends Sprite {
 
 	public static const ONCHANGE:String = 'onchange';
+	public static const ONCOLORCHANGE:String = 'oncolorchange';
 	public static const ONFONTCHANGE:String = 'onfontchange';
 
 	private var editor:ImageEdit;
@@ -224,6 +225,10 @@ public class DrawPropertyUI extends Sprite {
 		}
 	}
 
+	public function showColorUI(isColor:Boolean):void{
+		colorPicker.visible = isColor;
+	}
+
 	public function showStrokeUI(isStroke:Boolean, isEraser:Boolean):void {
 		eraserStrokeDisplay.visible = isEraser;
 		eraserStrokeMode = isEraser;
@@ -241,6 +246,13 @@ public class DrawPropertyUI extends Sprite {
 		if (!disableEvents) dispatchEvent(new Event(ONCHANGE));
 		if (fillUI.visible) updateFillUI();
 		if (shapeUI.visible) updateShapeUI();
+	}
+
+	public function onColorChange():void{
+		sendChangeEvent();
+		dispatchEvent(new Event(ONCOLORCHANGE));
+
+
 	}
 
 	private function makeFillUI():void {

--- a/src/svgeditor/SVGEdit.as
+++ b/src/svgeditor/SVGEdit.as
@@ -28,7 +28,8 @@ package svgeditor {
 	import scratch.ScratchCostume;
 
 	import svgeditor.*;
-	import svgeditor.objs.*;
+import svgeditor.ColorPicker;
+import svgeditor.objs.*;
 	import svgeditor.tools.*;
 
 	import svgutils.*;
@@ -182,7 +183,7 @@ package svgeditor {
 			if(bSave) saveContent();
 		}
 
-		override protected function onColorChange(e:Event):void {
+		override protected function onDrawPropsChange(e:Event):void {
 			if(currentTool is SVGEditTool && (toolMode != 'select') && (toolMode != 'text')) {
 				var obj:ISVGEditable = (currentTool as SVGEditTool).getObject();
 				if(obj) {
@@ -194,9 +195,10 @@ package svgeditor {
 				}
 			}
 			else {
-				super.onColorChange(e);
+				super.onDrawPropsChange(e);
 			}
 		}
+
 
 		override protected function stageKeyDownHandler(event:KeyboardEvent):Boolean {
 			if(!super.stageKeyDownHandler(event)) {


### PR DESCRIPTION
```
-Also, Improving editor flow in minimally invasive ways
-Namely, certain UI elements should reappear when you click out of
ObjectTransformer mode
-Also, switching colors should deselect items, making it clear this
will not change the current object
-Doing this ^^ required factoring out true color change events from
other draw property changes
```
