### PR TITLE
Add the new WeDo 2.0 extension

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -716,7 +716,7 @@ public class Scratch extends Sprite {
 		if (jsEnabled) {
 			externalCall('ScratchExtensions.resetPlugin');
 		}
-		if (whenDone) {
+		if (whenDone != null) {
 			whenDone();
 		}
 	}

--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -712,9 +712,13 @@ public class Scratch extends Sprite {
 		}
 	}
 
-	public function resetPlugin():void {
-		if (jsEnabled)
+	public function resetPlugin(whenDone:Function):void {
+		if (jsEnabled) {
 			externalCall('ScratchExtensions.resetPlugin');
+		}
+		if (whenDone) {
+			whenDone();
+		}
 	}
 
 	protected function step(e:Event):void {

--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -814,7 +814,7 @@ public class Block extends Sprite {
 
 	public function showHelp():void {
 		var i:int = -1;
-		if((i = op.indexOf('.')) > -1) {
+		if((i = op.lastIndexOf('.')) > -1) {
 			var extName:String = op.substr(0, i);
 			if(Scratch.app.extensionManager.isInternal(extName))
 				Scratch.app.showTip('ext:'+extName);

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -49,7 +49,9 @@ public class ExtensionManager {
 	protected var extensionDict:Object = new Object(); // extension name -> extension record
 	private var justStartedWait:Boolean;
 	private var pollInProgress:Dictionary = new Dictionary(true);
-	static public const wedoExt:String = 'LEGO WeDo';
+	static public const picoBoardExt:String = 'PicoBoard';
+	static public const wedoExt:String = 'LEGO WeDo 1.0';
+	static public const wedo2Ext:String = 'LEGO WeDo 2.0';
 
 	public function ExtensionManager(app:Scratch) {
 		this.app = app;
@@ -72,8 +74,9 @@ public class ExtensionManager {
 
 		// Clear imported extensions before loading a new project.
 		extensionDict = {};
-		extensionDict['PicoBoard'] = ScratchExtension.PicoBoard();
+		extensionDict[picoBoardExt] = ScratchExtension.PicoBoard();
 		extensionDict[wedoExt] = ScratchExtension.WeDo();
+		extensionDict[wedo2Ext] = ScratchExtension.WeDo2();
 	}
 
 	// -----------------------------

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -295,7 +295,7 @@ public class ExtensionManager {
 
 	public function menuItemsFor(op:String, menuName:String):Array {
 		// Return a list of menu items for the given menu of the extension associated with op or null.
-		var i:int = op.indexOf('.');
+		var i:int = op.lastIndexOf('.');
 		if (i < 0) return null;
 		var ext:ScratchExtension = extensionDict[op.slice(0, i)];
 		if (!ext || !ext.menus) return null; // unknown extension
@@ -342,7 +342,7 @@ public class ExtensionManager {
 	//------------------------------
 
 	public function primExtensionOp(b:Block):* {
-		var i:int = b.op.indexOf('.');
+		var i:int = b.op.lastIndexOf('.');
 		var extName:String = b.op.slice(0, i);
 		var ext:ScratchExtension = extensionDict[extName];
 		if (ext == null) return 0; // unknown extension

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -50,7 +50,7 @@ public class ExtensionManager {
 	private var justStartedWait:Boolean;
 	private var pollInProgress:Dictionary = new Dictionary(true);
 	static public const picoBoardExt:String = 'PicoBoard';
-	static public const wedoExt:String = 'LEGO WeDo 1.0';
+	static public const wedoExt:String = 'LEGO WeDo';
 	static public const wedo2Ext:String = 'LEGO WeDo 2.0';
 
 	public function ExtensionManager(app:Scratch) {

--- a/src/extensions/ScratchExtension.as
+++ b/src/extensions/ScratchExtension.as
@@ -85,7 +85,7 @@ public class ScratchExtension {
 		var result:ScratchExtension = new ScratchExtension(ExtensionManager.wedoExt, 0);
 		result.isInternal = true;
 		result.javascriptURL = Scratch.app.server.getOfficialExtensionURL('wedoExtension.js');
-		result.thumbnailMD5 = 'c323d815dee53ca545d71fdc107af708.png';
+		result.thumbnailMD5 = '9e5933c3b8b76596d1f889d44d3715a1.png';
 		result.url = 'http://wiki.scratch.mit.edu/wiki/LEGO_WeDo_Blocks';
 		result.tags = ['hardware'];
 		return result;
@@ -96,7 +96,7 @@ public class ScratchExtension {
 		var result:ScratchExtension = new ScratchExtension(ExtensionManager.wedo2Ext, 0);
 		result.isInternal = true;
 		result.javascriptURL = Scratch.app.server.getOfficialExtensionURL('wedo2Extension.js');
-		result.thumbnailMD5 = 'f20bd801dbeb1359f6f384fd942d9314.png';
+		result.thumbnailMD5 = 'c14047e09787cd75a2bc6aba68ceb0de.png';
 		result.url = 'http://wiki.scratch.mit.edu/wiki/LEGO_WeDo2_Blocks'; // TODO
 		result.tags = ['hardware'];
 		return result;

--- a/src/extensions/ScratchExtension.as
+++ b/src/extensions/ScratchExtension.as
@@ -42,6 +42,15 @@ import flash.utils.Dictionary;
 public class ScratchExtension {
 
 	public var name:String = '';
+
+	private var _displayName:String = '';
+	public function get displayName():String{
+		return _displayName ? _displayName : name;
+	}
+	public function set displayName(val:String):void{
+		_displayName = val;
+	}
+
 	public var host:String = '127.0.0.1'; // most extensions run on the local host
 	public var port:int = 0;
 	public var id:uint = 0;
@@ -88,6 +97,7 @@ public class ScratchExtension {
 		result.thumbnailMD5 = '9e5933c3b8b76596d1f889d44d3715a1.png';
 		result.url = 'http://wiki.scratch.mit.edu/wiki/LEGO_WeDo_Blocks';
 		result.tags = ['hardware'];
+		result.displayName = "LEGO WeDo 1.0";
 		return result;
 	}
 

--- a/src/extensions/ScratchExtension.as
+++ b/src/extensions/ScratchExtension.as
@@ -71,7 +71,7 @@ public class ScratchExtension {
 
 	public static function PicoBoard():ScratchExtension {
 		// Return a descriptor for the Scratch PicoBoard extension.
-		var result:ScratchExtension = new ScratchExtension('PicoBoard', 0);
+		var result:ScratchExtension = new ScratchExtension(ExtensionManager.picoBoardExt, 0);
 		result.isInternal = true;
 		result.javascriptURL = Scratch.app.server.getOfficialExtensionURL('picoExtension.js');
 		result.thumbnailMD5 = '82318df0f682b1de33f64da8726660dc.png';
@@ -85,8 +85,19 @@ public class ScratchExtension {
 		var result:ScratchExtension = new ScratchExtension(ExtensionManager.wedoExt, 0);
 		result.isInternal = true;
 		result.javascriptURL = Scratch.app.server.getOfficialExtensionURL('wedoExtension.js');
-		result.thumbnailMD5 = 'c4a6bfa4cb9f4d71b3d1e65db63cb761.png';
+		result.thumbnailMD5 = 'c323d815dee53ca545d71fdc107af708.png';
 		result.url = 'http://wiki.scratch.mit.edu/wiki/LEGO_WeDo_Blocks';
+		result.tags = ['hardware'];
+		return result;
+	}
+
+	public static function WeDo2():ScratchExtension {
+		// Return a descriptor for the LEGO WeDo 2.0 extension.
+		var result:ScratchExtension = new ScratchExtension(ExtensionManager.wedo2Ext, 0);
+		result.isInternal = true;
+		result.javascriptURL = Scratch.app.server.getOfficialExtensionURL('wedo2Extension.js');
+		result.thumbnailMD5 = 'f20bd801dbeb1359f6f384fd942d9314.png';
+		result.url = 'http://wiki.scratch.mit.edu/wiki/LEGO_WeDo2_Blocks'; // TODO
 		result.tags = ['hardware'];
 		return result;
 	}

--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -299,7 +299,7 @@ public class Interpreter {
 		if (!b) return 0; // arg() and friends can pass null if arg index is out of range
 		var op:String = b.op;
 		if (b.opFunction == null) {
-			if (op.indexOf('.') > -1) b.opFunction = app.extensionManager.primExtensionOp;
+			if (op.lastIndexOf('.') > -1) b.opFunction = app.extensionManager.primExtensionOp;
 			else b.opFunction = (primTable[op] == undefined) ? primNoop : primTable[op];
 		}
 

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -56,7 +56,7 @@ public class BlockMenus implements DragClient {
 			if ((comparisonOps.indexOf(op)) > -1) { menuHandler.changeOpMenu(evt, comparisonOps); return; }
 			if (menuName == null) { menuHandler.genericBlockMenu(evt); return; }
 		}
-		if (op.indexOf('.') > -1 && menuHandler.extensionMenu(evt, menuName)) return;
+		if (op.lastIndexOf('.') > -1 && menuHandler.extensionMenu(evt, menuName)) return;
 		if (menuName == 'attribute') menuHandler.attributeMenu(evt);
 		if (menuName == 'backdrop') menuHandler.backdropMenu(evt);
 		if (menuName == 'booleanSensor') menuHandler.booleanSensorMenu(evt);

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -380,7 +380,7 @@ public class PaletteBuilder {
 				// Open in the tips window if the URL starts with /info/ and another tab otherwise
 				if (ext.url.indexOf('/info/') === 0) app.showTip(ext.url);
 				else if (ext.url.indexOf('http') === 0) navigateToURL(new URLRequest(ext.url));
-				else DialogBox.notify('Extensions', 'Unable to load about page: the URL given for extension "' + ext.name + '" is not formatted correctly.');
+				else DialogBox.notify('Extensions', 'Unable to load about page: the URL given for extension "' + ext.displayName + '" is not formatted correctly.');
 			}
 		}
 
@@ -390,7 +390,7 @@ public class PaletteBuilder {
 		}
 
 		var m:Menu = new Menu();
-		m.addItem(Translator.map('About') + ' ' + ext.name + ' ' + Translator.map('extension') + '...', showAbout, !!ext.url);
+		m.addItem(Translator.map('About') + ' ' + ext.displayName + ' ' + Translator.map('extension') + '...', showAbout, !!ext.url);
 		m.addItem('Remove extension blocks', hideExtension);
 
 		var extensionDevManager:ExtensionDevManager = Scratch.app.extensionManager as ExtensionDevManager;
@@ -423,7 +423,7 @@ public class PaletteBuilder {
 
 		nextY += 7;
 
-		var titleButton:IconButton = UIPart.makeMenuButton(ext.name, extensionMenu, true, CSS.textColor);
+		var titleButton:IconButton = UIPart.makeMenuButton(ext.displayName, extensionMenu, true, CSS.textColor);
 		titleButton.x = 5;
 		titleButton.y = nextY;
 		app.palette.addChild(titleButton);

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -820,7 +820,7 @@ public class ScratchRuntime {
 			if (spr) spr.setDirection(spr.direction);
 		}
 
-		app.resetPlugin(function() {
+		app.resetPlugin(function():void {
 			app.extensionManager.clearImportedExtensions();
 			app.extensionManager.loadSavedExtensions(project.info.savedExtensions);
 		});

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -603,7 +603,7 @@ public class ScratchRuntime {
 	}
 
 	private function isUnofficialExtensionBlock(b:Block):Boolean {
-		var i:int = b.op.indexOf('.');
+		var i:int = b.op.lastIndexOf('.');
 		if(i == -1) return false;
 		var extName:String = b.op.substr(0, i);
 		return !app.extensionManager.isInternal(extName);
@@ -663,7 +663,7 @@ public class ScratchRuntime {
 				activeHats.push(hat);
 			}
 		} else if (app.jsEnabled) {
-			var dotIndex:int = hat.op.indexOf('.');
+			var dotIndex:int = hat.op.lastIndexOf('.');
 			if (dotIndex > -1) {
 				var extName:String = hat.op.substr(0, dotIndex);
 				if (app.extensionManager.extensionActive(extName)) {

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -820,9 +820,10 @@ public class ScratchRuntime {
 			if (spr) spr.setDirection(spr.direction);
 		}
 
-		app.resetPlugin();
-		app.extensionManager.clearImportedExtensions();
-		app.extensionManager.loadSavedExtensions(project.info.savedExtensions);
+		app.resetPlugin(function() {
+			app.extensionManager.clearImportedExtensions();
+			app.extensionManager.loadSavedExtensions(project.info.savedExtensions);
+		});
 		app.installStage(project);
 		app.updateSpriteLibrary(true);
 		// set the active sprite

--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -335,7 +335,7 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 		for each (var ext:ScratchExtension in extList) {
 			allItems.push(new MediaLibraryItem({
 				extension: ext,
-				name: ext.name,
+				name: ext.displayName,
 				md5: ext.thumbnailMD5,
 				tags: ext.tags
 			}));

--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -328,7 +328,9 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 	protected function addScratchExtensions():void {
 		const extList:Array = [
 			ScratchExtension.PicoBoard(),
-			ScratchExtension.WeDo()];
+			ScratchExtension.WeDo(),
+			ScratchExtension.WeDo2()
+		];
 		allItems = [];
 		for each (var ext:ScratchExtension in extList) {
 			allItems.push(new MediaLibraryItem({

--- a/src/watchers/Watcher.as
+++ b/src/watchers/Watcher.as
@@ -183,7 +183,7 @@ public class Watcher extends Sprite implements DragClient {
 	}
 
 	private function specForCmd():String {
-		var i:int = cmd.indexOf('.');
+		var i:int = cmd.lastIndexOf('.');
 		if(i > -1) {
 			var spec:Array = Scratch.app.extensionManager.specForCmd(cmd);
 			if(spec) return cmd.substr(0, i) + ': '+spec[0];
@@ -238,7 +238,7 @@ public class Watcher extends Sprite implements DragClient {
 			case "yScroll": return app.stagePane.yScroll;
 		}
 
-		if(cmd.indexOf('.') > -1) {
+		if(cmd.lastIndexOf('.') > -1) {
 			var spec:Array = Scratch.app.extensionManager.specForCmd(cmd);
 			if(spec) {
 				block = new Block(spec[0], spec[1], Specs.blockColor(spec[2]), spec[3]);


### PR DESCRIPTION
Requires LLK/scratchr2#3371 for online support
- Support extensions whose names contain '.'
- Add the WeDo 2.0 extension to the Extension Library
- Update the name and icon for the WeDo 1.0 extension
- Alter `resetPlugin()` to support a bug fix in the offline editor
