### PR TITLE
Reset requester state when args might have changed

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -622,6 +622,10 @@ public class Block extends Sprite {
 	private function collectArgs():void {
 		var i:int;
 		args = [];
+		if (isRequester && requestState == 2) {
+			// Assume this means that our args have changed. See https://github.com/LLK/scratchx/issues/61
+			requestState = 0;
+		}
 		for (i = 0; i < labelsAndArgs.length; i++) {
 			var a:* = labelsAndArgs[i];
 			if ((a is Block) || (a is BlockArg)) args.push(a);


### PR DESCRIPTION
The `collectArgs()` function runs when anything changes in the arguments of a block or any of its descendants, recursively. If this is called on a Requester block which currently has a value, reset / discard that value in case it's no longer valid given the argument change.

This resolves LLK/scratchx#61