### PR TITLE
Added valid XML check to SVG decoding

### DIFF
--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -171,7 +171,14 @@ public class ScratchCostume {
 		data.position = 0;
 		var s:String = data.readUTFBytes(10);
 		data.position = oldPosition;
-		return (s.indexOf('<?xml') >= 0) || (s.indexOf('<svg') >= 0);
+		var validXML:Boolean = true;
+		try{
+			XML(data)
+		}
+		catch (e:*){
+			validXML = false;
+		}
+		return ((s.indexOf('<?xml') >= 0) || (s.indexOf('<svg') >= 0)) && validXML;
 	}
 
 	public static function emptySVG():ByteArray {


### PR DESCRIPTION
    -As a catch all, you must be able to make a valid XML object from
    the (potentially) SVG data
    -Adding this to isSVGData seems to engage the preexisting error
    handling functionality