### PR TITLE
Poor type safety in endCurrentTool caused err. 1096

### DIFF
--- a/src/svgeditor/ImageEdit.as
+++ b/src/svgeditor/ImageEdit.as
@@ -30,6 +30,7 @@ import flash.utils.ByteArray;
 import scratch.*;
 
 import svgeditor.objs.*;
+import svgeditor.objs.ISVGEditable;
 import svgeditor.tools.*;
 
 import svgutils.*;
@@ -767,12 +768,14 @@ public class ImageEdit extends Sprite {
 			setToolMode("select");
 		}
 		// If the tool wasn't canceled and an object was created then select it
-		if (nextObject && nextObject.width > 0 && nextObject.height > 0 && (nextObject is Selection || nextObject.parent)) {
-			if(!(this is SVGEdit)){
-				setToolMode("bitmapSelect");
-			}
-			var s:Selection = (nextObject is Selection ? nextObject : new Selection([nextObject]));
-			objectTransformer.select(s);
+		var displayObject:DisplayObject = nextObject as DisplayObject;
+		if (nextObject &&
+				((displayObject  && displayObject.width > 0 && displayObject.height > 0 ) || (nextObject is Selection))) {
+				if(!(this is SVGEdit)){
+					setToolMode("bitmapSelect");
+				}
+				var s:Selection = (nextObject is Selection ? nextObject : new Selection([nextObject]));
+				objectTransformer.select(s);
 		}
 		else if((this is SVGEdit) && repeatedTools.indexOf(lastToolMode) > -1){
 			setToolMode(lastToolMode);

--- a/src/svgeditor/ImageEdit.as
+++ b/src/svgeditor/ImageEdit.as
@@ -770,7 +770,7 @@ public class ImageEdit extends Sprite {
 		// If the tool wasn't canceled and an object was created then select it
 		var displayObject:DisplayObject = nextObject as DisplayObject;
 		if (nextObject &&
-				((displayObject  && displayObject.width > 0 && displayObject.height > 0 ) || (nextObject is Selection))) {
+				((displayObject && displayObject.parent && displayObject.width > 0 && displayObject.height > 0 ) || (nextObject is Selection))) {
 				if(!(this is SVGEdit)){
 					setToolMode("bitmapSelect");
 				}


### PR DESCRIPTION
```
-This is not a permanent fix, but solves the problem while touching
at little as possible, and will not throw even if unexpected types
are received.
```
