### PR TITLE
Move 'when Stage clicked' to blocks strings

### DIFF
--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -57,7 +57,7 @@ public class PaletteBuilder {
 			'Stage selected:', 'No motion blocks',
 			'Make a Block', 'Make a List', 'Make a Variable',
 			'New List', 'List name', 'New Variable', 'Variable name',
-			'New Block', 'Add an Extension', 'when Stage clicked'];
+			'New Block', 'Add an Extension'];
 	}
 
 	public function showBlocksForCategory(selectedCategory:int, scrollToOrigin:Boolean, shiftKey:Boolean = false):void {

--- a/src/ui/PaletteSelector.as
+++ b/src/ui/PaletteSelector.as
@@ -43,7 +43,11 @@ public class PaletteSelector extends Sprite {
 		initCategories();
 	}
 
-	public static function strings():Array { return categories }
+	public static function strings():Array {
+		return categories.concat([
+			'when Stage clicked'
+		]);
+	}
 	public function updateTranslation():void { initCategories() }
 
 	public function select(id:int, shiftKey:Boolean = false):void {


### PR DESCRIPTION
The string "when Stage clicked" was showing up in the "UI" strings export (the "Scratch Editor" project in Pootle) instead of the "commands" export (the "Scratch Blocks" project in Pootle). This change fixes that, resolving #1031.

Note that this only affects string export, so it doesn't need to be deployed to take effect. Translators will see the change as soon as the exported files are imported into Pootle.