### PR TITLE
Fix 1044 extension separator

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -814,13 +814,17 @@ public class Block extends Sprite {
 	}
 
 	public function showHelp():void {
-		var i:int = -1;
-		if((i = op.lastIndexOf('.')) > -1) {
-			var extName:String = op.substr(0, i);
-			if(Scratch.app.extensionManager.isInternal(extName))
-				Scratch.app.showTip('ext:'+extName);
-			else
-				DialogBox.notify('Help Missing', 'There is no documentation available for experimental extension "'+extName+'".', Scratch.app.stage);
+		var extName:String = ExtensionManager.unpackExtensionName(op);
+		if (extName) {
+			if (Scratch.app.extensionManager.isInternal(extName)) {
+				Scratch.app.showTip('ext:' + extName);
+			}
+			else {
+				DialogBox.notify(
+						'Help Missing',
+						'There is no documentation available for experimental extension "' + extName + '".',
+						Scratch.app.stage);
+			}
 		}
 		else {
 			Scratch.app.showTip(op);

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -105,7 +105,7 @@ public class ExtensionManager {
 	// Retrieve the extension name from `prefixedOp`.
 	// If `prefixedOp` doesn't have an extension prefix, return `null`.
 	public static function unpackExtensionName(prefixedOp:String):String {
-		var separatorPosition:int = prefixedOp.lastIndexOf(extensionSeparator);
+		var separatorPosition:int = prefixedOp.indexOf(extensionSeparator);
 		if (separatorPosition < 0) {
 			return null;
 		}
@@ -117,7 +117,7 @@ public class ExtensionManager {
 	// Unpack `prefixedOp` into `[extensionName, op]`
 	// If `prefixedOp` doesn't have an extension prefix, return `[null, prefixedOp]`
 	public static function unpackExtensionAndOp(prefixedOp:String):Array {
-		var separatorPosition:int = prefixedOp.lastIndexOf(extensionSeparator);
+		var separatorPosition:int = prefixedOp.indexOf(extensionSeparator);
 		if (separatorPosition < 0) {
 			return [null, prefixedOp];
 		}

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -49,6 +49,7 @@ public class ExtensionManager {
 	protected var extensionDict:Object = new Object(); // extension name -> extension record
 	private var justStartedWait:Boolean;
 	private var pollInProgress:Dictionary = new Dictionary(true);
+	static public const extensionSeparator:String = '\u001F';
 	static public const picoBoardExt:String = 'PicoBoard';
 	static public const wedoExt:String = 'LEGO WeDo';
 	static public const wedo2Ext:String = 'LEGO WeDo 2.0';
@@ -83,10 +84,10 @@ public class ExtensionManager {
 	// Block Specifications
 	//------------------------------
 
+	// Return a command spec array for the given operation or null.
 	public function specForCmd(op:String):Array {
-		// Return a command spec array for the given operation or null.
 		for each (var ext:ScratchExtension in extensionDict) {
-			var prefix:String = ext.useScratchPrimitives ? '' : (ext.name + '.');
+			var prefix:String = ext.useScratchPrimitives ? '' : (ext.name + extensionSeparator);
 			for each (var spec:Array in ext.blockSpecs) {
 				if ((spec.length > 2) && ((prefix + spec[2]) == op)) {
 					return [spec[1], spec[0], Specs.extensionsCategory, op, spec.slice(3)];
@@ -94,6 +95,35 @@ public class ExtensionManager {
 			}
 		}
 		return null;
+	}
+
+	// Check whether `prefixedOp` is prefixed with an extension name.
+	public static function hasExtensionPrefix(prefixedOp:String):Boolean {
+		return prefixedOp.indexOf(extensionSeparator) >= 0;
+	}
+
+	// Retrieve the extension name from `prefixedOp`.
+	// If `prefixedOp` doesn't have an extension prefix, return `null`.
+	public static function unpackExtensionName(prefixedOp:String):String {
+		var separatorPosition:int = prefixedOp.lastIndexOf(extensionSeparator);
+		if (separatorPosition < 0) {
+			return null;
+		}
+		else {
+			return prefixedOp.substr(0, separatorPosition);
+		}
+	}
+
+	// Unpack `prefixedOp` into `[extensionName, op]`
+	// If `prefixedOp` doesn't have an extension prefix, return `[null, prefixedOp]`
+	public static function unpackExtensionAndOp(prefixedOp:String):Array {
+		var separatorPosition:int = prefixedOp.lastIndexOf(extensionSeparator);
+		if (separatorPosition < 0) {
+			return [null, prefixedOp];
+		}
+		else {
+			return [prefixedOp.substr(0, separatorPosition), prefixedOp.substr(separatorPosition+1)];
+		}
 	}
 
 	// -----------------------------
@@ -298,9 +328,9 @@ public class ExtensionManager {
 
 	public function menuItemsFor(op:String, menuName:String):Array {
 		// Return a list of menu items for the given menu of the extension associated with op or null.
-		var i:int = op.lastIndexOf('.');
-		if (i < 0) return null;
-		var ext:ScratchExtension = extensionDict[op.slice(0, i)];
+		var extName:String = unpackExtensionName(op);
+		if (!extName) return null;
+		var ext:ScratchExtension = extensionDict[extName];
 		if (!ext || !ext.menus) return null; // unknown extension
 		return ext.menus[menuName];
 	}
@@ -345,13 +375,13 @@ public class ExtensionManager {
 	//------------------------------
 
 	public function primExtensionOp(b:Block):* {
-		var i:int = b.op.lastIndexOf('.');
-		var extName:String = b.op.slice(0, i);
+		var unpackedOp:Array = unpackExtensionAndOp(b.op);
+		var extName:String = unpackedOp[0];
 		var ext:ScratchExtension = extensionDict[extName];
 		if (ext == null) return 0; // unknown extension
-		var primOrVarName:String = b.op.slice(i + 1);
+		var primOrVarName:String = unpackedOp[1];
 		var args:Array = [];
-		for (i = 0; i < b.args.length; i++) {
+		for (var i:int = 0; i < b.args.length; i++) {
 			args.push(app.interp.arg(b, i));
 		}
 

--- a/src/interpreter/Interpreter.as
+++ b/src/interpreter/Interpreter.as
@@ -56,13 +56,19 @@
 // Delay times are rounded to milliseconds, and the minimum delay is a millisecond.
 
 package interpreter {
-	import flash.utils.Dictionary;
-	import flash.utils.getTimer;
-	import flash.geom.Point;
-	import blocks.*;
-	import primitives.*;
-	import scratch.*;
-	import sound.*;
+import blocks.*;
+
+import extensions.ExtensionManager;
+
+import flash.geom.Point;
+import flash.utils.Dictionary;
+import flash.utils.getTimer;
+
+import primitives.*;
+
+import scratch.*;
+
+import sound.*;
 
 public class Interpreter {
 
@@ -299,7 +305,7 @@ public class Interpreter {
 		if (!b) return 0; // arg() and friends can pass null if arg index is out of range
 		var op:String = b.op;
 		if (b.opFunction == null) {
-			if (op.lastIndexOf('.') > -1) b.opFunction = app.extensionManager.primExtensionOp;
+			if (ExtensionManager.hasExtensionPrefix(op)) b.opFunction = app.extensionManager.primExtensionOp;
 			else b.opFunction = (primTable[op] == undefined) ? primNoop : primTable[op];
 		}
 

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -18,17 +18,26 @@
  */
 
 package scratch {
-	import flash.display.*;
-	import flash.events.*;
-	import flash.geom.*;
-	import flash.ui.*;
-	import blocks.*;
-	import filters.*;
-	import sound.*;
-	import translation.Translator;
-	import ui.ProcedureSpecEditor;
-	import uiwidgets.*;
-	import util.*;
+import blocks.*;
+
+import extensions.ExtensionManager;
+
+import filters.*;
+
+import flash.display.*;
+import flash.events.*;
+import flash.geom.*;
+import flash.ui.*;
+
+import sound.*;
+
+import translation.Translator;
+
+import ui.ProcedureSpecEditor;
+
+import uiwidgets.*;
+
+import util.*;
 
 public class BlockMenus implements DragClient {
 
@@ -56,7 +65,7 @@ public class BlockMenus implements DragClient {
 			if ((comparisonOps.indexOf(op)) > -1) { menuHandler.changeOpMenu(evt, comparisonOps); return; }
 			if (menuName == null) { menuHandler.genericBlockMenu(evt); return; }
 		}
-		if (op.lastIndexOf('.') > -1 && menuHandler.extensionMenu(evt, menuName)) return;
+		if (ExtensionManager.hasExtensionPrefix(op) && menuHandler.extensionMenu(evt, menuName)) return;
 		if (menuName == 'attribute') menuHandler.attributeMenu(evt);
 		if (menuName == 'backdrop') menuHandler.backdropMenu(evt);
 		if (menuName == 'booleanSensor') menuHandler.booleanSensorMenu(evt);

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -497,7 +497,7 @@ public class PaletteBuilder {
 
 	private function addBlocksForExtension(ext:ScratchExtension):void {
 		var blockColor:int = Specs.extensionsColor;
-		var opPrefix:String = ext.useScratchPrimitives ? '' : ext.name + '.';
+		var opPrefix:String = ext.useScratchPrimitives ? '' : ext.name + ExtensionManager.extensionSeparator;
 		for each (var spec:Array in ext.blockSpecs) {
 			if (spec.length >= 3) {
 				var op:String = opPrefix + spec[2];

--- a/src/watchers/Watcher.as
+++ b/src/watchers/Watcher.as
@@ -24,19 +24,25 @@
 // Represents a variable display.
 
 package watchers {
-import blocks.BlockIO;
+import blocks.Block;
+
+import extensions.ExtensionManager;
 
 import flash.display.*;
-	import flash.filters.BevelFilter;
-	import flash.events.MouseEvent;
-	import flash.geom.Point;
-	import flash.text.*;
-	import interpreter.*;
-	import scratch.*;
-	import uiwidgets.*;
-	import util.*;
-	import blocks.Block;
-	import translation.Translator;
+import flash.events.MouseEvent;
+import flash.filters.BevelFilter;
+import flash.geom.Point;
+import flash.text.*;
+
+import interpreter.*;
+
+import scratch.*;
+
+import translation.Translator;
+
+import uiwidgets.*;
+
+import util.*;
 
 public class Watcher extends Sprite implements DragClient {
 
@@ -183,10 +189,10 @@ public class Watcher extends Sprite implements DragClient {
 	}
 
 	private function specForCmd():String {
-		var i:int = cmd.lastIndexOf('.');
-		if(i > -1) {
+		var extName:String = ExtensionManager.unpackExtensionName(cmd);
+		if (extName) {
 			var spec:Array = Scratch.app.extensionManager.specForCmd(cmd);
-			if(spec) return cmd.substr(0, i) + ': '+spec[0];
+			if (spec) return extName + ': ' + spec[0];
 		}
 
 		for each (var entry:Array in Specs.commands) {
@@ -238,9 +244,9 @@ public class Watcher extends Sprite implements DragClient {
 			case "yScroll": return app.stagePane.yScroll;
 		}
 
-		if(cmd.lastIndexOf('.') > -1) {
+		if(ExtensionManager.hasExtensionPrefix(cmd)) {
 			var spec:Array = Scratch.app.extensionManager.specForCmd(cmd);
-			if(spec) {
+			if (spec) {
 				block = new Block(spec[0], spec[1], Specs.blockColor(spec[2]), spec[3]);
 				return Scratch.app.interp.evalCmd(block);
 			}


### PR DESCRIPTION
Prior to the WeDo 2.0 extension, Scratch assumed that an extension's name would never contain `.` -- Scratch would split an extension op string into an extension name and an op within that extension by looking for the first `.`.

With the WeDo 2.0 extension, I changed the code to split on the last `.` so that "2.0" in the extension name wouldn't cause problems. Unfortunately this broke extensions which use `.` in their blocks.

This change uses U+001F (Unicode "Unit Separator") as the separator instead of `.` since U+001F is very unlikely to be contained in an extension's name or blocks. The separator and unpacking logic have been centralized in `ExtensionManager` as well.

This resolves #1044
