### PR TITLE
Eliminate 'rR' block type hack

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -31,19 +31,24 @@
 // sequence from a specification string (e.g. "%n + %n") and type (e.g. reporter).
 
 package blocks {
+import assets.Resources;
+
 import extensions.ExtensionManager;
 
 import flash.display.*;
-	import flash.events.*;
-	import flash.filters.GlowFilter;
-	import flash.geom.*;
-	import flash.net.URLLoader;
-	import flash.text.*;
-	import assets.Resources;
-	import translation.Translator;
-	import util.*;
-	import uiwidgets.*;
-	import scratch.*;
+import flash.events.*;
+import flash.filters.GlowFilter;
+import flash.geom.*;
+import flash.net.URLLoader;
+import flash.text.*;
+
+import scratch.*;
+
+import translation.Translator;
+
+import uiwidgets.*;
+
+import util.*;
 
 public class Block extends Sprite {
 
@@ -77,7 +82,7 @@ public class Block extends Sprite {
 
 	// Blocking operations
 	public var isRequester:Boolean = false;
-	public var forcedRequester:Boolean = false;	// We've forced requester-like treatment on a non-requester block.
+	public var forceAsync:Boolean = false;	// We've forced requester-like treatment on a non-requester block.
 	public var requestState:int = 0;		// 0 - no request made, 1 - awaiting response, 2 - data ready
 	public var response:* = null;
 	public var requestLoader:URLLoader = null;
@@ -130,12 +135,12 @@ public class Block extends Sprite {
 			isReporter = true;
 			indentLeft = 9;
 			indentRight = 7;
-		} else if (type == "r" || type == "R" || type == "rR") {
+		} else if (type == "r" || type == "R") {
 			this.type = 'r';
 			base = new BlockShape(BlockShape.NumberShape, color);
 			isReporter = true;
-			isRequester = ((type == 'R') || (type == 'rR'));
-			forcedRequester = (type == 'rR');
+			forceAsync = (type == 'r') && Scratch.app.extensionManager.shouldForceAsync();
+			isRequester = (type == 'R') || forceAsync;
 			indentTop = 2;
 			indentBottom = 2;
 			indentLeft = 6;
@@ -554,7 +559,7 @@ public class Block extends Sprite {
 		if (op == 'whenClicked') newSpec = forStage ? 'when Stage clicked' : 'when this sprite clicked';
 		var dup:Block = new Block(newSpec, type, (int)(forClone ? -1 : base.color), op);
 		dup.isRequester = isRequester;
-		dup.forcedRequester = forcedRequester;
+		dup.forceAsync = forceAsync;
 		dup.parameterNames = parameterNames;
 		dup.defaultArgValues = defaultArgValues;
 		dup.warpProcFlag = warpProcFlag;

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -80,6 +80,12 @@ public class ExtensionManager {
 		extensionDict[wedo2Ext] = ScratchExtension.WeDo2();
 	}
 
+	// Should the interpreter force async communication with extensions?
+	// For example, should 'r' be treated as 'R'?
+	public function shouldForceAsync():Boolean {
+		return app.isOffline;
+	}
+
 	// -----------------------------
 	// Block Specifications
 	//------------------------------
@@ -237,16 +243,6 @@ public class ExtensionManager {
 			ext = new ScratchExtension(extObj.extensionName, extObj.extensionPort);
 		ext.port = extObj.extensionPort;
 		ext.blockSpecs = extObj.blockSpecs;
-		if (app.isOffline && (ext.port == 0)) {
-			// Fix up block specs to force reporters to be treated as requesters.
-			// This is because the offline JS interface doesn't support returning values directly.
-			for each(var spec:Object in ext.blockSpecs) {
-				if(spec[0] == 'r') {
-					// 'r' is reporter, 'R' is requester, and 'rR' is a reporter forced to act as a requester.
-					spec[0] = 'rR';
-				}
-			}
-		}
 		if(extObj.url) ext.url = extObj.url;
 		ext.showBlocks = true;
 		ext.menus = extObj.menus;
@@ -504,7 +500,7 @@ public class ExtensionManager {
 			ext.busy.push(ext.nextID);
 			ext.waiting[b] = ext.nextID;
 
-			if (b.forcedRequester) {
+			if (b.forceAsync) {
 				// We're forcing a non-requester to be treated as a requester
 				app.externalCall('ScratchExtensions.getReporterForceAsync', null, ext.name, op, args, ext.nextID);
 			} else {

--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -503,7 +503,7 @@ public class PaletteBuilder {
 				var op:String = opPrefix + spec[2];
 				var defaultArgs:Array = spec.slice(3);
 				var block:Block = new Block(spec[1], spec[0], blockColor, op, defaultArgs);
-				var showCheckbox:Boolean = (spec[0] == 'r' && defaultArgs.length == 0);
+				var showCheckbox:Boolean = (block.isReporter && !block.isRequester && defaultArgs.length == 0);
 				if (showCheckbox) addReporterCheckbox(block);
 				addItem(block, showCheckbox);
 			} else {


### PR DESCRIPTION
In the offline editor, reporters must be treated as requesters. This had been implemented by converting `'r'` blocks into `'rR'` blocks, but this ended up "leaking" into SB2s saved from the offline editor, which in turn caused problems with the online editor.

Now, the `Block` constructor calls the new `shouldForceAsync()` method on `ExtensionManager` to determine whether or not to set `forceAsync` (renamed from `forceRequester`). The block type/spec is never altered.

In support of this change, the logic for showing the watcher checkbox was updated to base its decision on the constructed block rather than the block spec.

I tried to keep #1032 in mind while making this change; my hope is that this technique will work well there, too.

This resolves #1051