### PR TITLE
Fix logic typo in isUnofficialExtensionBlock()

### DIFF
--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -621,7 +621,7 @@ public class ScratchRuntime {
 
 	private function isUnofficialExtensionBlock(b:Block):Boolean {
 		var extName:String = ExtensionManager.unpackExtensionName(b.op);
-		return !(extName && app.extensionManager.isInternal(extName));
+		return extName && !app.extensionManager.isInternal(extName);
 	}
 
 	SCRATCH::allow3d


### PR DESCRIPTION
This function was previously returning `true` for non-extension blocks.
