### PR TITLE
Fix up blocks after loading HTTP extension

### DIFF
--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -316,6 +316,7 @@ public class ExtensionManager {
 			setEnabled(extObj.extensionName, true);
 		}
 		Scratch.app.updatePalette();
+		Scratch.app.translationChanged();
 	}
 
 	// -----------------------------


### PR DESCRIPTION
After recent changes to extension loading and the `resetPlugin()` sequence, HTTP extensions are no longer reliably loaded early enough to avoid the need to update their blocks afterward. Calling `translationChanged()` calls `updateScriptsAfterTranslation()` on each object, replacing red error blocks with proper extension blocks.

This resolves #1058