### PR TITLE
fix chinese font size been too small. (fix  issue #875)

### DIFF
--- a/src/translation/Translator.as
+++ b/src/translation/Translator.as
@@ -41,7 +41,7 @@ public class Translator {
 	public static var rightToLeft:Boolean;
 	public static var rightToLeftMath:Boolean; // true only for Arabic
 
-	private static const font12:Array = ['fa', 'he','ja','ja_HIRA', 'zh_CN'];
+	private static const font12:Array = ['fa', 'he','ja','ja_HIRA', 'zh_CN', 'zh-cn', 'zh_TW', 'zh-tw'];
 	private static const font13:Array = ['ar'];
 
 	private static var dictionary:Object = {};
@@ -124,7 +124,7 @@ public class Translator {
 		rightToLeft = rtlLanguages.indexOf(lang) > -1;
 		rightToLeftMath = ('ar' == lang);
 		Block.setFonts(10, 9, true, 0); // default font settings
-		if (font12.indexOf(lang) > -1) Block.setFonts(11, 10, false, 0);
+		if (font12.indexOf(lang) > -1) Block.setFonts(12, 11, false, 0);
 		if (font13.indexOf(lang) > -1) Block.setFonts(13, 12, false, 0);
 	}
 


### PR DESCRIPTION
I find the issue "Default Chinese Character Font Size Larger #875" hasn't been solved. Because the code change doesn't worked .

The reason that it failed is because the files in the locale folder . We have 2 po files for chinese (zh_CN.po zh-cn.po ) and 2 po files for taiwanese (zh_TW.po zh-tw.po) . So I fixed the array to include all these 4 files.

Also the size of the font is still not big enough. So I increase font size a little bit.

I built it in my machine and it worked ! Hope the code could help students in chinese and taiwan for learning Scratch. #875