### PR TITLE
Fix `forceAsync` logic

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -140,7 +140,7 @@ public class Block extends Sprite {
 			this.type = 'r';
 			base = new BlockShape(BlockShape.NumberShape, color);
 			isReporter = true;
-			forceAsync = (type == 'r') && Scratch.app.extensionManager.shouldForceAsync();
+			forceAsync = (type == 'r') && Scratch.app.extensionManager.shouldForceAsync(op);
 			isRequester = (type == 'R') || forceAsync;
 			indentTop = 2;
 			indentBottom = 2;
@@ -149,7 +149,7 @@ public class Block extends Sprite {
 		} else if (type == "h" || type == 'H') {
 			base = new BlockShape(BlockShape.HatShape, color);
 			isHat = true;
-			forceAsync = (type == 'h') && Scratch.app.extensionManager.shouldForceAsync();
+			forceAsync = (type == 'h') && Scratch.app.extensionManager.shouldForceAsync(op);
 			isAsyncHat = (type == 'H') || forceAsync;
 			indentTop = 12;
 		}

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -82,8 +82,21 @@ public class ExtensionManager {
 
 	// Should the interpreter force async communication with extensions?
 	// For example, should 'r' be treated as 'R'?
-	public function shouldForceAsync():Boolean {
-		return app.isOffline;
+	public function shouldForceAsync(op:String):Boolean {
+		// Non-extension blocks shouldn't be forceAsync
+		var extensionName:String = unpackExtensionName(op);
+		if (!extensionName) return false;
+
+		var extension:ScratchExtension = extensionDict[extensionName];
+		if (extension && extension.port != 0) {
+			// HTTP extensions should never be forceAsync
+			return false;
+		}
+		else {
+			// JS extensions should be forceAsync in the offline editor.
+			// If the extension is not loaded, guess that it's JS. Really that shouldn't ever happen...
+			return app.isOffline;
+		}
 	}
 
 	// -----------------------------


### PR DESCRIPTION
A block should only be `forceAsync` if the block is from a JS extension and running in a context where the JS interface is async. Currently the only such context is the offline editor.
Built-in blocks and HTTP extension blocks should never `forceAsync`.

This resolves #1066 and a variety of other issues.