### PR TITLE
Fix RTL block menus

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -1609,7 +1609,15 @@ public class Scratch extends Sprite {
 
 	public function externalCall(functionName:String, returnValueCallback:Function = null, ...args):void {
 		args.unshift(functionName);
-		var retVal:* = ExternalInterface.call.apply(ExternalInterface, args);
+		var retVal:*;
+		try {
+			retVal = ExternalInterface.call.apply(ExternalInterface, args);
+		}
+		catch (e:Error)
+		{
+			logException(e);
+			// fall through to below
+		}
 		if (returnValueCallback != null) {
 			returnValueCallback(retVal);
 		}

--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -240,6 +240,19 @@ public class Block extends Sprite {
 		}
 	}
 
+	// Convert a left-to-right argument index into a current argument index:
+	// - If the block is LTR, then return the index as it is,
+	// - Otherwise count back from the end to return the new index.
+	public function getNormalizedArgIndex(ltrIndex:int):int {
+		return rightToLeft ? args.length - 1 - ltrIndex : ltrIndex;
+	}
+
+	// Retrieve the argument which would have the given index in LTR mode,
+	// regardless of whether this block is currently LTR or RTL.
+	public function getNormalizedArg(ltrIndex:int):* {
+		return args[getNormalizedArgIndex(ltrIndex)];
+	}
+
 	public function normalizedArgs():Array {
 		return rightToLeft ? args.concat().reverse() : args;
 	}

--- a/src/blocks/BlockIO.as
+++ b/src/blocks/BlockIO.as
@@ -295,8 +295,8 @@ public class BlockIO {
 			'gotoSpriteOrMouse:', 'pointTowards:', 'touching:'];
 		if (refCmds.indexOf(b.op) < 0) return;
 		var arg:BlockArg;
-		if ((b.args.length == 1) && (b.args[0] is BlockArg)) arg = b.args[0];
-		if ((b.args.length == 2) && (b.args[1] is BlockArg)) arg = b.args[1];
+		if ((b.args.length == 1) && (b.getNormalizedArg(0) is BlockArg)) arg = b.getNormalizedArg(0);
+		if ((b.args.length == 2) && (b.getNormalizedArg(1) is BlockArg)) arg = b.getNormalizedArg(1);
 		if (arg) {
 			var oldVal:String = arg.argValue;
 			if (oldVal == 'edge' || oldVal == '_edge_') arg.setArgValue('_edge_', Translator.map('edge'));

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -216,10 +216,13 @@ public class BlockMenus implements DragClient {
 	}
 
 	private function attributeMenu(evt:MouseEvent):void {
-		var obj:*;
-		if (block && block.args[1]) {
-			if (block.args[1] is BlockArg) obj = app.stagePane.objNamed(block.args[1].argValue);
-			else obj = app.stagePane;  // this gives it the stage menus, but it's better than nothing
+		// If all else fails, fall back to the stage menus (better than nothing?)
+		var obj:* = app.stagePane;
+		if (block) {
+			var targetArg:BlockArg = block.getNormalizedArg(1) as BlockArg;
+			if (targetArg) {
+				obj = app.stagePane.objNamed(targetArg.argValue);
+			}
 		}
 		var attributes:Array = obj is ScratchStage ? stageAttributes : spriteAttributes;
 		var m:Menu = new Menu(setBlockArg, 'attribute');
@@ -412,10 +415,11 @@ public class BlockMenus implements DragClient {
 			else blockArg.setArgValue(s);
 			if (block.op == 'getAttribute:of:') {
 				var obj:ScratchObj = app.stagePane.objNamed(s);
-				var attr:String = block.args[0].argValue;
+				var attribArg:BlockArg = block.getNormalizedArg(0);
+				var attr:String = attribArg.argValue;
 				var validAttrs:Array = obj && obj.isStage ? stageAttributes : spriteAttributes;
 				if (validAttrs.indexOf(attr) == -1 && !obj.ownsVar(attr)) {
-					block.args[0].setArgValue(validAttrs[0]);
+					attribArg.setArgValue(validAttrs[0]);
 				}
 			}
 			Scratch.app.setSaveNeeded();

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -431,7 +431,7 @@ public class BlockMenus implements DragClient {
 		if (includeEdge) m.addItem(Translator.map('edge'), 'edge');
 		m.addLine();
 		if (includeStage) {
-			m.addItem(app.stagePane.objName, 'Stage');
+			m.addItem(Translator.map('Stage'), 'Stage');
 			m.addLine();
 		}
 		if (includeSelf && !app.viewedObj().isStage) {


### PR DESCRIPTION
The code for the `getAttribute:of:` block was not RTL-aware and had been mixing up the two menus on the block. Fixing this led me to discover a few other RTL-related issues as well.

This resolves #984 as well as the following:
- Changing from an LTR language (like English) to an RTL language (like Hebrew) with the `{X position} of {Stage}` block in the scripting area would change "Stage" to "_stage_" instead of its proper translation. This could happen for some other blocks and other targets as well. Here's the list of blocks and targets which run through that code, though only some of these were affected by the problem:
  - blocks: `createCloneOf`, `distanceTo:`, `getAttribute:of:`, `gotoSpriteOrMouse:`, `pointTowards:`, `touching:`
  - targets: `_edge_`, `_mouse_`, `_myself_`, `_stage_`, `_random_`
- In drop-down menus which allow the user to select the stage (such as `{X position} of {Stage}`), the word "Stage" was always shown in English.
