### PR TITLE
Handle image load errors more gracefully

### DIFF
--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -658,7 +658,7 @@ public class ScratchCostume {
 		return '.dat'; // generic data; should not happen
 	}
 
-	public function generateOrFindComposite(allCostumes:Array):void {
+	public function generateOrFindComposite(allCostumes:Vector.<ScratchCostume>):void {
 		// If this costume has a text layer bitmap, compute or find a composite bitmap.
 		// Since there can be multiple copies of the same costume, first try to find a
 		// costume with the same base and text layer bitmaps and share its composite

--- a/src/svgutils/SVGImporter.as
+++ b/src/svgutils/SVGImporter.as
@@ -271,7 +271,7 @@ public class SVGImporter {
 			imagesLoaded++;
 			if ((imagesLoaded == imageCount) && (whenDone != null)) whenDone(root);
 		}
-		var imageCount:int, imagesLoaded:int;
+		var imageCount:int = 0, imagesLoaded:int = 0;
 		for each (var el:SVGElement in root.allElements()) {
 			if (('image' == el.tag) && (el.bitmap == null)) {
 				imageCount++;

--- a/src/util/ProjectIO.as
+++ b/src/util/ProjectIO.as
@@ -55,8 +55,22 @@ public class ProjectIO {
 		this.app = app;
 	}
 
+	private static var translationStrings:Object = {
+		imageLoadingErrorTitle: 'Image Loading Error',
+		imageLoadingErrorHeader: 'At least one backdrop or costume failed to load:',
+		imageLoadingErrorBackdrop: 'Backdrop: {costumeName}',
+		imageLoadingErrorSprite: 'Sprite: {spriteName}',
+		imageLoadingErrorCostume: 'Costume: {costumeName}'
+	};
+
 	public static function strings():Array {
-		return [];
+		var result:Array = [];
+		for each (var key:String in translationStrings) {
+			if (translationStrings.hasOwnProperty(key)) {
+				result.push(translationStrings[key]);
+			}
+		}
+		return result;
 	}
 
 	//----------------------------
@@ -243,20 +257,28 @@ public class ProjectIO {
 		var errorCostumes:Vector.<ScratchCostume> = new Vector.<ScratchCostume>(2);
 
 		function makeErrorImage(obj:ScratchObj, c:ScratchCostume):* {
-			// TODO: translation?
 			if (!errorDialog) {
 				errorDialog = new DialogBox();
-				errorDialog.addTitle('Image loading error');
-				errorDialog.addText('At least one backdrop or costume failed to load:\n');
-			}
-			if (obj.isStage) {
-				errorDialog.addText('Backdrop: ' + c.costumeName + '\n');
-			}
-			else {
-				errorDialog.addText('Sprite: ' + obj.objName + '\nCostume: ' + c.costumeName + '\n');
+				errorDialog.addTitle(translationStrings.imageLoadingErrorTitle);
+				errorDialog.addText(Translator.map(translationStrings.imageLoadingErrorHeader) +'\n');
 			}
 
-			var errorCostumeIndex:int = 0 + obj.isStage;
+			var itemText:String;
+			if (obj.isStage) {
+				itemText = Translator.map(translationStrings.imageLoadingErrorBackdrop);
+			}
+			else {
+				itemText = Translator.map(translationStrings.imageLoadingErrorSprite) + '\n' +
+						Translator.map(translationStrings.imageLoadingErrorCostume);
+			}
+
+			var context:Dictionary = new Dictionary();
+			context['spriteName'] = obj.objName;
+			context['costumeName'] = c.costumeName;
+			itemText = StringUtils.substitute(itemText, context);
+			errorDialog.addText(itemText + '\n');
+
+			var errorCostumeIndex:int = int(obj.isStage);
 			var errorCostume:ScratchCostume = errorCostumes[errorCostumeIndex] =
 					errorCostumes[errorCostumeIndex] || ScratchCostume.emptyBitmapCostume('', obj.isStage);
 			return errorCostume.baseLayerBitmap;

--- a/src/util/ProjectIO.as
+++ b/src/util/ProjectIO.as
@@ -207,48 +207,113 @@ public class ProjectIO {
 		}
 	}
 
+	// Load all images in all costumes from their image data, then call whenDone.
 	public function decodeAllImages(objList:Array, whenDone:Function, fail:Function = null):void {
-		// Load all images in all costumes from their image data, then call whenDone.
-		function imageDecoded():void {
-			for each (var o:* in imageDict) {
-				if (o == 'loading...') return; // not yet finished loading
+		// This should be called on success or failure of each image
+		function imageDone():void {
+			if (--numImagesToDecode == 0) {
+				allImagesLoaded(objList, imageDict, whenDone, fail);
 			}
-			allImagesLoaded();
-		}
-		var error:Boolean = false;
-		function decodeError():void {
-			if (error) return;
-			error = true;
-			if (fail != null) fail();
-		}
-		function allImagesLoaded():void {
-			if (error) return;
-			for each (c in allCostumes) {
-				if ((c.baseLayerData != null) && (c.baseLayerBitmap == null)) {
-					var img:* = imageDict[c.baseLayerData];
-					if (img is BitmapData) c.baseLayerBitmap = img;
-					if (img is SVGElement) c.setSVGRoot(img, false);
-				}
-				if ((c.textLayerData != null) && (c.textLayerBitmap == null)) c.textLayerBitmap = imageDict[c.textLayerData];
-			}
-			for each (c in allCostumes) c.generateOrFindComposite(allCostumes);
-			whenDone();
 		}
 
-		var c:ScratchCostume;
-		var allCostumes:Array = [];
-		for each (var o:ScratchObj in objList) {
-			for each (c in o.costumes) allCostumes.push(c);
-		}
+		var numImagesToDecode:int = 1; // start at 1 to prevent early finish
 		var imageDict:Dictionary = new Dictionary(); // maps image data to BitmapData
-		for each (c in allCostumes) {
-			if ((c.baseLayerData != null) && (c.baseLayerBitmap == null)) {
-				if (ScratchCostume.isSVGData(c.baseLayerData)) decodeSVG(c.baseLayerData, imageDict, imageDecoded);
-				else decodeImage(c.baseLayerData, imageDict, imageDecoded, decodeError);
+		for each (var obj:ScratchObj in objList) {
+			for each (var c:ScratchCostume in obj.costumes) {
+				if ((c.baseLayerData != null) && (c.baseLayerBitmap == null)) {
+					++numImagesToDecode;
+					if (ScratchCostume.isSVGData(c.baseLayerData)) {
+						decodeSVG(c.baseLayerData, imageDict, imageDone);
+					}
+					else {
+						decodeImage(c.baseLayerData, imageDict, imageDone, imageDone);
+					}
+				}
+				if ((c.textLayerData != null) && (c.textLayerBitmap == null)) {
+					++numImagesToDecode;
+					decodeImage(c.textLayerData, imageDict, imageDone, imageDone);
+				}
 			}
-			if ((c.textLayerData != null) && (c.textLayerBitmap == null)) decodeImage(c.textLayerData, imageDict, imageDecoded, decodeError);
 		}
-		imageDecoded(); // handles case when there were no images to load
+		// decrement the artificial 1 and also handle the case where no images are present.
+		imageDone();
+	}
+
+	private function allImagesLoaded(objList:Array, imageDict:Dictionary, whenDone:Function, fail:Function):void {
+		var errorCostumes:Vector.<ScratchCostume> = new Vector.<ScratchCostume>(2);
+
+		function makeErrorImage(obj:ScratchObj, c:ScratchCostume):* {
+			// TODO: translation?
+			if (!errorDialog) {
+				errorDialog = new DialogBox();
+				errorDialog.addTitle('Image loading error');
+				errorDialog.addText('At least one backdrop or costume failed to load:\n');
+			}
+			if (obj.isStage) {
+				errorDialog.addText('Backdrop: ' + c.costumeName + '\n');
+			}
+			else {
+				errorDialog.addText('Sprite: ' + obj.objName + '\nCostume: ' + c.costumeName + '\n');
+			}
+
+			var errorCostumeIndex:int = 0 + obj.isStage;
+			var errorCostume:ScratchCostume = errorCostumes[errorCostumeIndex] =
+					errorCostumes[errorCostumeIndex] || ScratchCostume.emptyBitmapCostume('', obj.isStage);
+			return errorCostume.baseLayerBitmap;
+		}
+
+		var allCostumes:Vector.<ScratchCostume> = new <ScratchCostume>[];
+		var errorDialog:DialogBox;
+		var img:*; // either BitmapData or SVGElement
+
+		for each (var obj:ScratchObj in objList) {
+			for each (var c:ScratchCostume in obj.costumes) {
+				allCostumes.push(c);
+				if ((c.baseLayerData != null) && (c.baseLayerBitmap == null)) {
+					img = imageDict[c.baseLayerData];
+					if (!img) {
+						c.baseLayerBitmap = makeErrorImage(obj, c);
+						c.baseLayerData = null;
+					}
+					else if (img is BitmapData) {
+						c.baseLayerBitmap = img;
+					}
+					else if (img is SVGElement) {
+						c.setSVGRoot(img, false);
+					}
+				}
+				if ((c.textLayerData != null) && (c.textLayerBitmap == null)) {
+					img = imageDict[c.textLayerData];
+					if (img) {
+						c.textLayerBitmap = imageDict[c.textLayerData];
+					}
+					else {
+						c.textLayerBitmap = makeErrorImage(obj, c);
+						c.textLayerData = null;
+					}
+				}
+			}
+		}
+		for each (c in allCostumes) {
+			c.generateOrFindComposite(allCostumes);
+		}
+
+		if (errorDialog) {
+			errorDialog.addButton('OK', errorDialog.accept);
+			errorDialog.showOnStage(Scratch.app.stage);
+
+			if (fail != null) {
+				fail();
+			}
+			else if (whenDone != null) {
+				whenDone();
+			}
+		}
+		else {
+			if (whenDone != null) {
+				whenDone();
+			}
+		}
 	}
 
 	private function decodeImage(imageData:ByteArray, imageDict:Dictionary, doneFunction:Function, fail:Function):void {
@@ -264,7 +329,6 @@ public class ProjectIO {
 			if (fail != null) fail();
 			return;
 		}
-		imageDict[imageData] = 'loading...';
 		var loader:Loader = new Loader();
 		loader.contentLoaderInfo.addEventListener(Event.COMPLETE, loadDone);
 		loader.contentLoaderInfo.addEventListener(IOErrorEvent.IO_ERROR, loadError);
@@ -276,13 +340,16 @@ public class ProjectIO {
 			imageDict[svgData] = svgRoot;
 			doneFunction();
 		}
-		if (imageDict[svgData] != null) return; // already loading or loaded
+		if (imageDict[svgData] != null) {
+			// already loading or loaded
+			doneFunction();
+			return;
+		}
 		var importer:SVGImporter = new SVGImporter(XML(svgData));
 		if (importer.hasUnloadedImages()) {
-			imageDict[svgData] = 'loading...';
 			importer.loadAllImages(loadDone);
 		} else {
-			imageDict[svgData] = importer.root;
+			loadDone(importer.root);
 		}
 	}
 


### PR DESCRIPTION
Prior to this change, any error encountered on any image (costume or backdrop) in the project would abort the `decodeAllImages` process. Unfortunately this was handled in such a way that it would cause the project to never finish loading, resulting in projects getting stuck at 100% on the loading progress bar.

Now, images which fail to load are replaced with an empty bitmap costume. In addition, such failures are reported to the user in a dialog at the end of the loading process. This report includes the sprite name (if applicable) and the costume/backdrop name for each failure.

This may also cause a small load-time speedup for projects with many costumes or backdrops due to the elimination of the `for each` in `decodeAllImages/imageDecoded()`.

This resolves #1085.

Things to test:
- The projects mentioned in #1085 should now finish loading and mention which costume was corrupted.
- Loading projects from "My Stuff" should work correctly: bitmap and vector costumes should appear as expected.
- A sprite or costume imported from a bitmap (PNG, JPG, etc.) or SVG should appear in the editor as expected.
- After any of the above tests, it should be possible to load a different SB2 file. If nothing happens when trying to load the SB2 file, that implies the previous project load process never finished.

@bsb20 @sclements
The more eyes on this, the merrier :)
