### PR TITLE
Check more carefully for Scratch stage clicks

### DIFF
--- a/src/util/GestureHandler.as
+++ b/src/util/GestureHandler.as
@@ -343,6 +343,15 @@ public class GestureHandler {
 		}
 	}
 
+	// Returns true if non-null `ancestor` is `descendant` or one of its ancestors.
+	private static function isAncestor(ancestor:DisplayObject, descendant:DisplayObject):Boolean {
+		while (descendant) {
+			if (ancestor == descendant) return true;
+			descendant = descendant.parent;
+		}
+		return false;
+	}
+
 	private function findMouseTarget(evt:MouseEvent, target:*):DisplayObject {
 		// Find the mouse target for the given event. Return null if no target found.
 
@@ -350,6 +359,19 @@ public class GestureHandler {
 		if ((target is Button) || (target is IconButton)) return null;
 
 		var o:DisplayObject = evt.target as DisplayObject;
+
+		var checkScratchStage:Boolean;
+		if (o == stage) {
+			var rect:Rectangle = app.stageObj().getRect(stage);
+			checkScratchStage = rect.contains(evt.stageX, evt.stageY);
+		}
+		else {
+			checkScratchStage = isAncestor(app.stageObj(), o);
+		}
+		if (checkScratchStage) {
+			return findMouseTargetOnStage(evt.stageX / app.scaleX, evt.stageY / app.scaleY);
+		}
+
 		var mouseTarget:Boolean = false;
 		while (o != null) {
 			if (isMouseTarget(o, evt.stageX / app.scaleX, evt.stageY / app.scaleY)) {
@@ -358,11 +380,7 @@ public class GestureHandler {
 			}
 			o = o.parent;
 		}
-		var rect:Rectangle = app.stageObj().getRect(stage);
-		if(!mouseTarget && rect.contains(evt.stageX, evt.stageY))  return findMouseTargetOnStage(evt.stageX / app.scaleX, evt.stageY / app.scaleY);
-		if (o == null) return null;
 		if ((o is Block) && Block(o).isEmbeddedInProcHat()) return o.parent;
-		if (o is ScratchObj) return findMouseTargetOnStage(evt.stageX / app.scaleX, evt.stageY / app.scaleY);
 		return o;
 	}
 


### PR DESCRIPTION
Before: any click within the rectangle of the Scratch stage would be forwarded to the top-most sprite at that (x,y) location, if any, even if the sprite was covered by some other UI such as a media library window.

After: a click is forwarded to the top-most sprite at its (x,y) location if Flash reports the target of the click is either the Flash stage (this covers 3D mode) or some descendant of the Scratch stage (this covers 2D mode).

Testing:
1. Download [click-test.zip](https://github.com/LLK/scratch-flash/files/253114/click-test.zip) (rename to SB2) or make a project with:
   - At least two visually distinct backdrops
   - At least one sprite with a script like `when this sprite clicked: switch backdrop to {next backdrop}`
2. Click on the sprite, verifying that the backdrop cycles.
3. Click near the sprite, verifying that the backdrop does not cycle.
4. Click in menus, in the scripting area, in text fields within blocks, etc. to verify that other mouse input works as expected.
5. Add an effect block such as `change {color} effect by {25}` to the scripting area. This will cause the Scratch stage to enter 3D mode.
6. Repeat steps 2-4 in 3D mode.

This resolves #1100
