### PR TITLE
Limit max size in RasterHull()

### DIFF
--- a/src/render3d/DisplayObjectContainerIn3D.as
+++ b/src/render3d/DisplayObjectContainerIn3D.as
@@ -26,7 +26,11 @@ package render3d {
 
 import flash.display.Sprite;
 
-public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
+public class DisplayObjectContainerIn3D extends Sprite {
+	public static var texSizeMax:int = 2048;
+	public static var texSize:int = 1024;
+	public static var maxTextures:uint = 15;
+SCRATCH::allow3d{
 	import com.adobe.utils.*;
 
 	import filters.FilterPack;
@@ -86,9 +90,6 @@ public class DisplayObjectContainerIn3D extends Sprite {SCRATCH::allow3d{
 	private var textures:Array;
 	private var testBMs:Array;
 	private var textureIndexByID:Object;
-	private static var texSizeMax:int = 2048;
-	private static var texSize:int = 1024;
-	private static var maxTextures:uint = 15;
 	private var penPacked:Boolean;
 
 	/** Triangle index data */

--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -305,7 +305,7 @@ public class ScratchCostume {
 		var s:Shape = shapeDict[id];
 		if (!s) {
 			s = new Shape();
-			var pts:Array = RasterHull();
+			var pts:Vector.<Point> = RasterHull();
 			s.graphics.clear();
 
 			if (pts.length) {
@@ -335,12 +335,14 @@ public class ScratchCostume {
 	 object is composed of
 	 ** a single point
 	 */
-	private function RasterHull():Array {
+	private function RasterHull():Vector.<Point> {
+		var H:Vector.<Point> = new Vector.<Point>();
 		var dispObj:DisplayObject = displayObj();
 		var r:Rectangle = dispObj.getBounds(dispObj);
-//trace('flash bounds: '+r);
-		if (r.width < 1 || r.height < 1)
-			return [new Point()];
+		if (r.width < 1 || r.height < 1) {
+			H.push(new Point());
+			return H;
+		}
 
 		r.width += Math.floor(r.left) - r.left;
 		r.left = Math.floor(r.left);
@@ -356,7 +358,6 @@ public class ScratchCostume {
 		}
 		// TODO: figure out why we add 1 to each dimension in addition to using Math.ceil above
 		var image:BitmapData = new BitmapData(desiredWidth + 1, desiredHeight + 1, true, 0);
-//trace('bitmap rect: '+image.rect);
 
 		var m:Matrix = new Matrix();
 		m.translate(-r.left, -r.top);
@@ -365,16 +366,10 @@ public class ScratchCostume {
 
 		var L:Vector.<Point> = new Vector.<Point>(image.height); //stack of left-side hull;
 		var R:Vector.<Point> = new Vector.<Point>(image.height); //stack of right side hull;
-		//var H:Vector.<Point> = new Vector.<Point>();
-		var H:Array = [];
 		var rr:int = -1, ll:int = -1;
 		var Q:Point = new Point();
 		var w:int = image.width;
 		var h:int = image.height;
-//		var minX:int = image.width;
-//		var minY:int = image.height;
-//		var maxX:int = 0;
-//		var maxY:int = 0;
 		var c:uint;
 		for (var y:int = 0; y < h; ++y) {
 			for (var x:int = 0; x < w; ++x) {
@@ -392,10 +387,6 @@ public class ScratchCostume {
 					--ll;
 			}
 
-//			minX = Math.min(minX, Q.x);
-//			minY = Math.min(minY, Q.y);
-//			maxX = Math.max(maxX, Q.x);
-//			maxY = Math.max(maxY, Q.y);
 			L[++ll] = Q.clone();
 			for (x = w - 1; x >= 0; --x) {//x=-1 never occurs;
 				c = (image.getPixel32(x, y) >> 24) & 0xff;
@@ -403,8 +394,6 @@ public class ScratchCostume {
 			}
 
 			Q.x = x + r.left;
-//			minX = Math.min(minX, Q.x);
-//			maxX = Math.max(maxX, Q.x);
 			while (rr > 0) {
 				if (CCW(R[rr - 1], R[rr], Q) > 0)
 					break;
@@ -424,7 +413,6 @@ public class ScratchCostume {
 		R.length = L.length = 0;
 		image.dispose();
 
-//trace('found bounds: '+new Rectangle(minX, minY, maxX - minX, maxY - minY));
 		return H;
 	}
 

--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -47,6 +47,8 @@ import flash.geom.*;
 import flash.text.TextField;
 import flash.utils.*;
 
+import render3d.DisplayObjectContainerIn3D;
+
 import svgeditor.objs.SegmentationState;
 
 import svgutils.*;
@@ -344,9 +346,16 @@ public class ScratchCostume {
 		r.left = Math.floor(r.left);
 		r.height += Math.floor(r.top) - r.top;
 		r.top = Math.floor(r.top);
-		var image:BitmapData = new BitmapData(
-				Math.max(1, Math.ceil(r.width) + 1), Math.max(
-						1, Math.ceil(r.height) + 1), true, 0);
+		var desiredWidth: int = Math.max(0, Math.ceil(r.width));
+		var desiredHeight: int = Math.max(0, Math.ceil(r.height));
+		if (desiredWidth >= DisplayObjectContainerIn3D.texSizeMax
+				|| desiredHeight >= DisplayObjectContainerIn3D.texSizeMax) {
+			var factor:Number = (DisplayObjectContainerIn3D.texSizeMax - 1) / Math.max(desiredWidth, desiredHeight);
+			desiredWidth *= factor;
+			desiredHeight *= factor;
+		}
+		// TODO: figure out why we add 1 to each dimension in addition to using Math.ceil above
+		var image:BitmapData = new BitmapData(desiredWidth + 1, desiredHeight + 1, true, 0);
 //trace('bitmap rect: '+image.rect);
 
 		var m:Matrix = new Matrix();


### PR DESCRIPTION
`RasterHull()` now limits the size of the `BitmapData` which it creates. The limit is the `texSizeMax` from `DisplayObjectContainerIn3D`, which is now public. Prior to this change the `BitmapData` size was not limited, which could cause an exception to be thrown by the `BitmapData` constructor.

To test:
- Open the browser console
- Load a project which exhibits this problem: https://app.getsentry.com/scratch-team/scratch-flash/issues/105167534/
  (or contact me for an SB2 which triggers the bug)

This is one of at least two issues which cause the symptom described in #1122
