### PR TITLE
Store bitmap resolution in backpack

### DIFF
--- a/src/scratch/ScratchCostume.as
+++ b/src/scratch/ScratchCostume.as
@@ -69,6 +69,7 @@ public class ScratchCostume {
 	private var __baseLayerData:ByteArray;
 
 	public static const WasEdited:int = -10; // special baseLayerID used to indicate costumes that have been edited
+	public static const kCalculateCenter:int = 99999; // calculate a default rotation center
 
 	public var svgRoot:SVGElement; // non-null for an SVG costume
 	public var svgLoading:Boolean; // true while loading bitmaps embedded in an SVG
@@ -95,7 +96,8 @@ public class ScratchCostume {
 
 	private var segmentation:SegmentationState = new SegmentationState();
 
-	public function ScratchCostume(name:String, data:*, centerX:int = 99999, centerY:int = 99999, bmRes:int = 1) {
+	public function ScratchCostume(
+			name:String, data:*, centerX:int = kCalculateCenter, centerY:int = kCalculateCenter, bmRes:int = 1) {
 		costumeName = name;
 		rotationCenterX = centerX;
 		rotationCenterY = centerY;
@@ -105,12 +107,12 @@ public class ScratchCostume {
 		else if (data is BitmapData) {
 			bitmap = baseLayerBitmap = data;
 			bitmapResolution = bmRes;
-			if (centerX == 99999) rotationCenterX = bitmap.rect.width / 2;
-			if (centerY == 99999) rotationCenterY = bitmap.rect.height / 2;
+			if (centerX == kCalculateCenter) rotationCenterX = bitmap.rect.width / 2;
+			if (centerY == kCalculateCenter) rotationCenterY = bitmap.rect.height / 2;
 			prepareToSave();
 		}
 		else if (data is ByteArray) {
-			setSVGData(data, (centerX == 99999));
+			setSVGData(data, (centerX == kCalculateCenter));
 			prepareToSave();
 		}
 	}

--- a/src/ui/media/MediaInfo.as
+++ b/src/ui/media/MediaInfo.as
@@ -54,6 +54,7 @@ public class MediaInfo extends Sprite {
 	public var objType:String = 'unknown';
 	public var objName:String = '';
 	public var objWidth:int = 0;
+	public var bitmapResolution:int = 1;
 	public var md5:String;
 
 	public var owner:ScratchObj; // object owning a sound or costume in MediaPane; null for other cases
@@ -96,6 +97,7 @@ public class MediaInfo extends Sprite {
 			objType = obj.type ? obj.type : '';
 			objName = obj.name ? obj.name : '';
 			objWidth = obj.width ? obj.width : 0;
+			bitmapResolution = obj.bitmapResolution ? obj.bitmapResolution : 1;
 			scripts = obj.scripts;
 			md5 = ('script' != objType) ? obj.md5 : null;
 		}
@@ -291,6 +293,9 @@ public class MediaInfo extends Sprite {
 		if (mycostume) {
 			result.width = mycostume.width();
 			result.height = mycostume.height();
+			if (mycostume.bitmapResolution != 1) {
+				result.bitmapResolution = mycostume.bitmapResolution;
+			}
 		}
 		if (mysound) {
 			result.seconds = mysound.getLengthInMsec() / 1000;

--- a/src/ui/media/MediaLibrary.as
+++ b/src/ui/media/MediaLibrary.as
@@ -443,9 +443,17 @@ spriteFeaturesFilter.visible = false; // disable features filter for now
 					io.fetchImage(md5AndExt, item.dbObj.name, 0, whenDone, obj);
 				} else { // assetType == backdrop
 					if (item.dbObj.info.length == 3) {
-						obj = {centerX: 99999, centerY: 99999, bitmapResolution: item.dbObj.info[2]};
+						obj = {
+							centerX: ScratchCostume.kCalculateCenter,
+							centerY: ScratchCostume.kCalculateCenter,
+							bitmapResolution: item.dbObj.info[2]
+						};
 					} else if (item.dbObj.info.length == 2 && item.dbObj.info[0] == 960 && item.dbObj.info[1] == 720) {
-						obj = {centerX: 99999, centerY: 99999, bitmapResolution: 2};
+						obj = {
+							centerX: ScratchCostume.kCalculateCenter,
+							centerY: ScratchCostume.kCalculateCenter,
+							bitmapResolution: 2
+						};
 					}
 					io.fetchImage(md5AndExt, item.dbObj.name, 0, whenDone, obj);
 				}


### PR DESCRIPTION
Along with a corresponding change in scratch-flash-online, this fixes backdrops "zooming in" in the backpack.
Also, make a class constant for the special value which causes ScratchCostume to calculate a default rotation center for the costume.

Testing:
- Backdrops in the backpack should no longer "zoom in":
  1. Add a backdrop to your backpack.
  2. Ensure that the thumbnail looks correct.
  3. Reload the project page
  4. Ensure that the thumbnail still looks correct.
- Costumes and backdrops outside of the backpack should not be affected in any way
  - The rotation center of sprites should still work as expected
- Other backpack items should not be affected in any way
