### PR TITLE
Keep parens on translation strings by default

### DIFF
--- a/src/translation/TranslatableStrings.as
+++ b/src/translation/TranslatableStrings.as
@@ -133,11 +133,11 @@ public class TranslatableStrings {
 		export('uiStrings');
 	}
 
-	public static function addAll(list:Array, removeParens:Boolean = true):void {
+	public static function addAll(list:Array, removeParens:Boolean = false):void {
 		for each (var s:String in list) add(s, removeParens);
 	}
 
-	public static function add(s:String, removeParens:Boolean = true):void {
+	public static function add(s:String, removeParens:Boolean = false):void {
 		if (removeParens) s = removeParentheticals(s);
 		s = removeWhitespace(s);
 		if ((s.length < 2) || (exclude.indexOf(s) > -1)) return;

--- a/src/uiwidgets/Menu.as
+++ b/src/uiwidgets/Menu.as
@@ -77,7 +77,8 @@ public class Menu extends Sprite {
 	public function showOnStage(stage:Stage, x:int = -1, y:int = -1):void {
 		if (stringCollectionMode) {
 			for each (var item:MenuItem in allItems) {
-				TranslatableStrings.add(item.getLabel());
+				// TODO: do we really want to remove parentheticals on all these?
+				TranslatableStrings.add(item.getLabel(), true);
 			}
 			return;
 		}


### PR DESCRIPTION
Previously, the translation string export process would remove parentheticals from all strings by default. There was a way to request that this should be skipped, but no callers used it.

Now, only one specific caller explicitly requests that parentheticals should be stripped and all other callers have their strings passed unmodified. This one specific caller is the only case where we actually expect parentheticals to be stripped.
