### PR TITLE
Allow drag-scroll iff scrollbars allowed, per axis

### DIFF
--- a/src/util/GestureHandler.as
+++ b/src/util/GestureHandler.as
@@ -133,9 +133,13 @@ public class GestureHandler {
 			}
 		}
 		if (carriedObj && scrollTarget && (getTimer() - scrollStartTime) > SCROLL_MSECS && (scrollXVelocity || scrollYVelocity)) {
-			if (!scrollTarget is ScriptsPane) {
+			if (scrollTarget.allowHorizontalScrollbar) {
 				scrollTarget.contents.x = Math.min(0, Math.max(-scrollTarget.maxScrollH(), scrollTarget.contents.x + scrollXVelocity));
+			}
+			if (scrollTarget.allowVerticalScrollbar) {
 				scrollTarget.contents.y = Math.min(0, Math.max(-scrollTarget.maxScrollV(), scrollTarget.contents.y + scrollYVelocity));
+			}
+			if (scrollTarget.allowHorizontalScrollbar || scrollTarget.allowVerticalScrollbar) {
 				scrollTarget.constrainScroll();
 				scrollTarget.updateScrollbars();
 			}


### PR DESCRIPTION
Previous behavior: drag-scrolling was generally allowed, except on `ScriptPane` targets. This prevented horizontal drag-scrolling in the block palette as desired, but unfortunately also prevented vertical drag-scrolling in the block palette and all drag-scrolling in the scripting area. It also allowed a slight "wiggle" in a few places, such as the costume list.

New behavior: horizontal drag-scrolling is allowed on any target which allows horizontal scrollbars, and vertical drag-scrolling is allowed on any target which allows vertical scrollbars. These are checked independently: areas like the sprite list, costume list, or block palette can drag-scroll vertically but not horizontally.

This is another attempt to fix #742.
See also #1080, which is not addressed by this change.

Testing:
- Verify that dragging a block near the edge of the block palette cannot cause horizontal scrolling. The "Sensing" blocks are good for this test.
- Verify that dragging a block near the top or bottom edge of the block palette can cause vertical scrolling.
- Verify that dragging a block near the edge of the scripting area can cause the scripting area to scroll both horizontally and vertically.
- Verify that dragging a sprite near the top or bottom of the sprite or costume list can cause those areas to scroll vertically, but not horizontally.