### PR TITLE
Speculative fixes for sounds being replaced by empty sound

### DIFF
--- a/src/scratch/ScratchSound.as
+++ b/src/scratch/ScratchSound.as
@@ -118,7 +118,6 @@ public class ScratchSound {
 				samples = (channels == 2) ? stereoToMono(samples, (newRate < rate)) : downsample(samples);
 			}
 			setSamples(samples, newRate, true);
-			soundID = 0;
 		}
 		else if ((soundData.length > compressionThreshold) && ('' == format)) {
 			// Compress large, uncompressed sounds

--- a/src/util/ProjectIO.as
+++ b/src/util/ProjectIO.as
@@ -457,7 +457,6 @@ public class ProjectIO {
 				snd = new ScratchSound(sndName, sndData); // try reading data as WAV file
 			} catch (e:*) { }
 			if (snd && (snd.sampleCount > 0)) { // WAV data
-				snd.md5 = id;
 				whenDone(snd);
 			} else { // try to read data as an MP3 file
 				MP3Loader.convertToScratchSound(sndName, sndData, whenDone);


### PR DESCRIPTION
Some users have reported valid sounds being replaced with an empty sound while working with the online editor. I have not been able to reproduce this behavior, but based on the evidence we've collected so far I made some guesses about what might be happening.

The changes here include:
- General cleanup & reformatting of the code in `ScratchSound.as`, including the removal of some long-unused code.
- Turn the `md5` property into a read-only property that is calculated on demand, cached, and invalidated when the sound data changes. This was already partially implemented, but now it's complete.
- Fix a case where a sound could arbitrarily get `soundID=0` even if that's the valid ID of another sound.
- Add some logging to error cases, which might help diagnose the problem if these changes don't fix it.

Note that the logging is currently set to use `LogLevel.WARNING` which means these events will show up in a browser console but won't be logged in Sentry. I could bump some of these new logging events to `LogLevel.ERROR` if we want to see them in Sentry, but I'm nervous about overwhelming our event quota.

Hopefully this fixes #1193
