### PR TITLE
Fix Boolean reporters in extensions when offline

### DIFF
--- a/src/blocks/Block.as
+++ b/src/blocks/Block.as
@@ -134,6 +134,8 @@ public class Block extends Sprite {
 		} else if (type == "b") {
 			base = new BlockShape(BlockShape.BooleanShape, color);
 			isReporter = true;
+			forceAsync = Scratch.app.extensionManager.shouldForceAsync(op);
+			isRequester = forceAsync;
 			indentLeft = 9;
 			indentRight = 7;
 		} else if (type == "r" || type == "R") {


### PR DESCRIPTION
Extension reporters must run asynchronously in the offline editor. This change makes Boolean reporters act like requesters in the offline editor, just like we do with non-Boolean reporters.

Note that we don't normally support Boolean requesters -- there's no `'B'` block type -- but the code to handle extension requesters doesn't care whether the block is Boolean or not so this change is sufficient. It would be trivial to add support for `'B'` now.

This resolves #1117
