### PR TITLE
Separate presentation mode request & reaction

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -628,6 +628,12 @@ public class Scratch extends Sprite {
 	protected var wasEditing:Boolean;
 
 	public function setPresentationMode(enterPresentation:Boolean):void {
+		if (stagePart.isInPresentationMode() != enterPresentation) {
+			presentationModeWasChanged(enterPresentation);
+		}
+	}
+
+	public function presentationModeWasChanged(enterPresentation:Boolean):void {
 		if (enterPresentation) {
 			wasEditing = editMode;
 			if (wasEditing) {
@@ -646,6 +652,7 @@ public class Scratch extends Sprite {
 		for each (var o:ScratchObj in stagePane.allObjects()) o.applyFilters();
 
 		if (lp) fixLoadProgressLayout();
+		stagePart.presentationModeWasChanged(enterPresentation);
 		stagePane.updateCostume();
 		SCRATCH::allow3d {
 			if (isIn3D) render3D.onStageResize();
@@ -660,7 +667,6 @@ public class Scratch extends Sprite {
 		// Escape exists presentation mode.
 		else if ((evt.charCode == 27) && stagePart.isInPresentationMode()) {
 			setPresentationMode(false);
-			stagePart.exitPresentationMode();
 		}
 		// Handle enter key
 //		else if(evt.keyCode == 13 && !stage.focus) {

--- a/src/ui/parts/StagePart.as
+++ b/src/ui/parts/StagePart.as
@@ -134,8 +134,8 @@ public class StagePart extends UIPart {
 	public function setProjectName(s:String):void { projectTitle.setContents(s) }
 	public function isInPresentationMode():Boolean { return fullscreenButton.visible && fullscreenButton.isOn() }
 
-	public function exitPresentationMode():void {
-		fullscreenButton.setOn(false);
+	public function presentationModeWasChanged(isPresentationMode:Boolean):void {
+		fullscreenButton.setOn(isPresentationMode);
 		drawOutline();
 		refresh();
 	}
@@ -435,7 +435,7 @@ public class StagePart extends UIPart {
 
 	private function addFullScreenButton():void {
 		function toggleFullscreen(b:IconButton):void {
-			app.setPresentationMode(b.isOn());
+			app.presentationModeWasChanged(b.isOn());
 			drawOutline();
 		}
 		fullscreenButton = new IconButton(toggleFullscreen, 'fullscreen');


### PR DESCRIPTION
For better or worse, the editor tracks "presentation mode" (full-screen) state in the state of the presentation mode toggle button. This is fine as long as that button is the only way to change presentation mode, but sometimes we want JavaScript to set the presentation mode state. This change separates the concept of requesting a mode change (such as when JS requests a state) from the reaction to a change (such as when the button is clicked, or the JS request results in a change).

This is part of a fix for LLK/scratchr2#3639
See also:
- LLK/scratchr2#4173
- LLK/scratch-flash-online#288
