### PR TITLE
Fix scratch-flash-online #102

### DIFF
--- a/src/scratch/ScratchSound.as
+++ b/src/scratch/ScratchSound.as
@@ -76,6 +76,7 @@ public class ScratchSound {
 
 	public function ScratchSound(name:String, sndData:ByteArray) {
 		this.soundName = name;
+		this.soundID = WasEdited;
 		if (sndData != null) {
 			try {
 				var info:Object = WAVFile.decode(sndData);
@@ -242,11 +243,7 @@ public class ScratchSound {
 			bitsPerSample = 4;
 		}
 		reduceSizeIfNeeded(1); // downsample or compress to reduce size before saving
-		if (soundID == WasEdited) {
-			// sound was edited; force md5 to be recomputed
-			__md5 = null;
-			soundID = -1;
-		}
+		soundID = -1;
 	}
 
 	public static function isWAV(data:ByteArray):Boolean {
@@ -269,6 +266,7 @@ public class ScratchSound {
 	public function readJSON(jsonObj:Object):void {
 		soundName = jsonObj.soundName;
 		soundID = jsonObj.soundID;
+		__md5 = jsonObj.md5; // Project load uses this value to fetch sound data
 		sampleCount = jsonObj.sampleCount;
 		rate = jsonObj.rate;
 		format = jsonObj.format;

--- a/src/sound/WAVFile.as
+++ b/src/sound/WAVFile.as
@@ -21,6 +21,8 @@ package sound {
 	import flash.utils.ByteArray;
 	import flash.utils.Endian;
 
+	import logging.LogLevel;
+
 public class WAVFile {
 
 	public static function empty():ByteArray {
@@ -119,7 +121,15 @@ public class WAVFile {
 
 	public static function extractSamples(waveData:ByteArray):Vector.<int> {
 		var result:Vector.<int> = new Vector.<int>();
-		var info:Object = WAVFile.decode(waveData);
+		var info:Object;
+		try {
+			info = WAVFile.decode(waveData);
+		}
+		catch (e:*) {
+			Scratch.app.log(LogLevel.WARNING, 'Error extracting samples from WAV file', {error: e});
+			result.push(0); // a WAV file must have at least one sample
+			return result;
+		}
 		var i:int;
 		var v:int;
 		if (info.encoding == 1) {


### PR DESCRIPTION
There are two changes here; see commits for detail. Summary:
- Fix a problem loading sounds, introduced by #1214 
- Catch and log errors during WAV decode rather than breaking the Sounds tab as described in LLK/scratch-flash-online#102

Testing:
- Make a new project.
- Save the project and reload it.
- Ensure that both sounds loaded correctly ("meow" on the sprite and "pop" on the backdrop).
- Add a new sound by clicking the "Record a new sound" button. Leave it empty.
- Save the project and reload it, then double-check that all three sounds are expected.
- Save the project to an SB2 and load that SB2 into the offline editor.
- Ensure that all three sounds loaded correctly in the offline editor.

This resolves LLK/scratch-flash-online#102 in its current sound-related form.
