### PR TITLE
Enforce bounds in ListWatcher's setWidthHeight()

### DIFF
--- a/src/watchers/ListWatcher.as
+++ b/src/watchers/ListWatcher.as
@@ -359,6 +359,14 @@ public class ListWatcher extends Sprite {
 	//------------------------------
 
 	public function setWidthHeight(w:int, h:int):void {
+		// Large (especially tall) list watchers can cause many, many list cells to be allocated, leading to delays.
+		// Bound the size so that updateContents() won't cause long delays for long lists.
+		var boundingObject:Object = this.parent || Scratch.app.stagePane || {width: 480, height: 360};
+		x = Math.max(0, Math.min(x, boundingObject.width - frame.minWidth));
+		y = Math.max(0, Math.min(y, boundingObject.height - frame.minHeight));
+		w = Math.max(frame.minWidth, Math.min(w, boundingObject.width - x));
+		h = Math.max(frame.minHeight, Math.min(h, boundingObject.height - y));
+
 		frame.setWidthHeight(w, h);
 		fixLayout();
 	}


### PR DESCRIPTION
The `ListWatcher` class creates a cell for each visible item as part of its resize handling (see `updateContents`). This can take a long time if the height of the list watcher and the length of its list are both very large. This is especially true at load-time, when a list watcher may not yet know what its true size should be.

This change enforces bounds in the `setWidthHeight()` method of the `ListWatcher` class. Bounding the size effectively bounds the number of list cells that will be created, eliminating long load-time delays.

This resolves #1223