### PR TITLE
Skip POSTs with empty body, output a warning

### DIFF
--- a/src/util/Server.as
+++ b/src/util/Server.as
@@ -225,6 +225,16 @@ public class Server implements IServer {
 			if (csrfCookie && (csrfCookie.length > 0)) {
 				request.requestHeaders.push(new URLRequestHeader('X-CSRFToken', csrfCookie));
 			}
+
+			if (data.length == 0) {
+				// Flash's URLLoader will convert a POST with a zero-length body into a GET; apparently there's no way
+				// to avoid that behavior.
+				// Most Scratch servers will respond to this with error 403, leading to other problems down the road.
+				// Since this situation likely means the asset is broken anyway, complain about it and skip the upload.
+				// It's better to, for example, save a project with one missing asset than to fail the save altogether.
+				onCallServerError(url, data, new ErrorEvent("Refusing to POST with empty body"));
+				return loader;
+			}
 		}
 
 		try {


### PR DESCRIPTION
Flash doesn't correctly handle a POST with an empty body: the URL
handler automatically converts the POST into a GET. This causes a 403
leading the editor to think the user has logged out. The end result is a
save failure that's to recover from.

A project shouldn't have a zero-length asset anyway, but if it does get
into that situation then this change will prevent the entire project
from being "lost" due to a single-asset error.

This resolves #1232 

Testing (see also https://github.com/LLK/scratch-flash/issues/1232#issuecomment-263382635):
1. Download [empty-POST.sb2.zip](https://github.com/LLK/scratch-flash/files/625870/empty-POST.sb2.zip) and optionally rename it to just "empty-POST.sb2"
2. Go to Scratch with a project you don't mind replacing (new project is fine)
3. Click "File" then "Upload from your computer"
4. Pick the SB2 you downloaded
5. Click "OK" when asked to replace the current project
6. Wait for the save to finish

Expected result after this change: The project saves correctly. The sprite has a sound called "empty-sound" which looks like it has contents but is actually empty. (This situation was created by hand-editing the project file.)

Result before this change: "you must log in to save" banner, user appears to be logged out until a page transition or reload. The browser console contains at least one error 403.

The failure case is easiest to test on Firefox; in Chrome you may see one or more instances of error 500. The editor will retry after a 500 so as long as the end result is as expected it's OK.