### PR TITLE
Sprite menu self-referencing: resolve #1139

### DIFF
--- a/src/primitives/SensingPrims.as
+++ b/src/primitives/SensingPrims.as
@@ -92,10 +92,9 @@ public class SensingPrims {
 		}
 		if (!s.visible) return false;
 
-		;
 		var sBM:BitmapData = s.bitmap(true);
 		for each (var s2:ScratchSprite in app.stagePane.spritesAndClonesNamed(arg))
-			if (s2.visible && sBM.hitTest(s.bounds().topLeft, 1, s2.bitmap(true), s2.bounds().topLeft, 1))
+			if (s != s2 && s2.visible && sBM.hitTest(s.bounds().topLeft, 1, s2.bitmap(true), s2.bounds().topLeft, 1))
 				return true;
 
 		return false;

--- a/src/primitives/SensingPrims.as
+++ b/src/primitives/SensingPrims.as
@@ -250,7 +250,9 @@ public class SensingPrims {
 
 	private function primGetAttribute(b:Block):* {
 		var attribute:String = interp.arg(b, 0);
-		var obj:ScratchObj = app.stagePane.objNamed(String(interp.arg(b, 1)));
+		var objName:String = interp.arg(b, 1);
+		var obj:ScratchObj = app.stagePane.objNamed(objName);
+		if ('_myself_' == objName) obj = interp.activeThread.target;
 		if (!(obj is ScratchObj)) return 0;
 		if (obj is ScratchSprite) {
 			var s:ScratchSprite = ScratchSprite(obj);

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -436,7 +436,7 @@ public class BlockMenus implements DragClient {
 		m.addLine();
 
 		for each (var sprite:ScratchSprite in app.stagePane.sprites()) {
-			if (includeSelf || sprite != app.viewedObj()) spriteNames.push(sprite.objName);
+			spriteNames.push(sprite.objName);
 		}
 		spriteNames.sort(Array.CASEINSENSITIVE);
 		for each (var spriteName:String in spriteNames) {

--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -92,7 +92,7 @@ public class BlockMenus implements DragClient {
 		if (menuName == 'spriteOnly') menuHandler.spriteMenu(evt, false, false, false, true, false);
 		if (menuName == 'spriteOrMouse') menuHandler.spriteMenu(evt, true, false, false, false, false);
 		if (menuName == 'location') menuHandler.spriteMenu(evt, true, false, false, false, true);
-		if (menuName == 'spriteOrStage') menuHandler.spriteMenu(evt, false, false, true, false, false);
+		if (menuName == 'spriteOrStage') menuHandler.spriteMenu(evt, false, false, true, true, false);
 		if (menuName == 'touching') menuHandler.spriteMenu(evt, true, true, false, false, false);
 		if (menuName == 'stageOrThis') menuHandler.stageOrThisSpriteMenu(evt);
 		if (menuName == 'stop') menuHandler.stopMenu(evt);
@@ -430,17 +430,13 @@ public class BlockMenus implements DragClient {
 		if (includeRandom) m.addItem(Translator.map('random position'), 'random position');
 		if (includeEdge) m.addItem(Translator.map('edge'), 'edge');
 		m.addLine();
-		if (includeStage) {
-			m.addItem(Translator.map('Stage'), 'Stage');
-			m.addLine();
-		}
-		if (includeSelf && !app.viewedObj().isStage) {
-			m.addItem(Translator.map('myself'), 'myself');
-			m.addLine();
-			spriteNames.push(app.viewedObj().objName);
-		}
+
+		if (includeStage) m.addItem(Translator.map('Stage'), 'Stage');
+		if (includeSelf && !app.viewedObj().isStage) m.addItem(Translator.map('myself'), 'myself');
+		m.addLine();
+
 		for each (var sprite:ScratchSprite in app.stagePane.sprites()) {
-			if (sprite != app.viewedObj()) spriteNames.push(sprite.objName);
+			if (includeSelf || sprite != app.viewedObj()) spriteNames.push(sprite.objName);
 		}
 		spriteNames.sort(Array.CASEINSENSITIVE);
 		for each (var spriteName:String in spriteNames) {

--- a/src/uiwidgets/ScriptsPane.as
+++ b/src/uiwidgets/ScriptsPane.as
@@ -367,7 +367,7 @@ return true; // xxx disable this check for now; it was causing confusion at Scra
 
 	private function dropCompatible(droppedBlock:Block, target:DisplayObject):Boolean {
 		const menusThatAcceptReporters:Array = [
-			'broadcast', 'costume', 'backdrop', 'scene', 'sound',
+			'attribute', 'broadcast', 'costume', 'backdrop', 'scene', 'sound',
 			'spriteOnly', 'spriteOrMouse', 'location', 'spriteOrStage', 'touching'];
 		if (!droppedBlock.isReporter) return true; // dropping a command block
 		if (target is Block) {

--- a/src/uiwidgets/ScriptsPane.as
+++ b/src/uiwidgets/ScriptsPane.as
@@ -367,7 +367,7 @@ return true; // xxx disable this check for now; it was causing confusion at Scra
 
 	private function dropCompatible(droppedBlock:Block, target:DisplayObject):Boolean {
 		const menusThatAcceptReporters:Array = [
-			'attribute', 'broadcast', 'costume', 'backdrop', 'scene', 'sound',
+			'broadcast', 'costume', 'backdrop', 'scene', 'sound',
 			'spriteOnly', 'spriteOrMouse', 'location', 'spriteOrStage', 'touching'];
 		if (!droppedBlock.isReporter) return true; // dropping a command block
 		if (target is Block) {


### PR DESCRIPTION
Submitting this to resolve #1139.

In summary, these changes add the current sprite in all sprite drop-down menus.  While this may seem redundant, note that the sprite field is in reference to the base sprite and not it's clones.  Many projects on scratch already take advantage of this distinction for advanced clone management (either by using a variable reporter, or by back-pack kung-fu).  This doesn't change any functionality of scratch.  I've also added an instance reference, "myself", to the sprite attribute sensor - both for variable selection convenience, as well as enables for some programmatically-generated variable management on the instance as some people have already been doing.

Some possibilities:
Sprite clones can now detect if they are touching their own kind
Sprite clones can now point at the sprite root
you can now access properties of a sprite via a reporter