### PR TITLE
Accept reporters in attribute menu

### DIFF
--- a/src/scratch/BlockMenus.as
+++ b/src/scratch/BlockMenus.as
@@ -217,14 +217,14 @@ public class BlockMenus implements DragClient {
 
 	private function attributeMenu(evt:MouseEvent):void {
 		// If all else fails, fall back to the stage menus (better than nothing?)
-		var obj:* = app.stagePane;
+		var obj:*;
 		if (block) {
 			var targetArg:BlockArg = block.getNormalizedArg(1) as BlockArg;
 			if (targetArg) {
 				obj = app.stagePane.objNamed(targetArg.argValue);
 			}
 		}
-		var attributes:Array = obj is ScratchStage ? stageAttributes : spriteAttributes;
+		var attributes:Array = obj? (obj is ScratchStage ? stageAttributes : spriteAttributes) : spriteAttributes;
 		var m:Menu = new Menu(setBlockArg, 'attribute');
 		for each (var s:String in attributes) m.addItem(s);
 		if (obj is ScratchObj) {

--- a/src/uiwidgets/ScriptsPane.as
+++ b/src/uiwidgets/ScriptsPane.as
@@ -367,7 +367,7 @@ return true; // xxx disable this check for now; it was causing confusion at Scra
 
 	private function dropCompatible(droppedBlock:Block, target:DisplayObject):Boolean {
 		const menusThatAcceptReporters:Array = [
-			'broadcast', 'costume', 'backdrop', 'scene', 'sound',
+			'attribute', 'broadcast', 'costume', 'backdrop', 'scene', 'sound',
 			'spriteOnly', 'spriteOrMouse', 'location', 'spriteOrStage', 'touching'];
 		if (!droppedBlock.isReporter) return true; // dropping a command block
 		if (target is Block) {


### PR DESCRIPTION
Very small change, but safe:
- allows reporters to be dropped on the attribute menu
- on the  "attribute of sprite/stage" block, If a reporter is dropped on the spriteOrStage menu, the attribute menu gives you the default list of sprite attributes (no variables, because the sprite is unknown)

The argument:
Scratch already allows reporters to be dropped on the sprite/stage field of an "attribute of sprite/stage" block.  If someone chose to do so, it's safe to assume that they're trying to access a sprite programmatically, not the stage, because the stage name is always the same.  The problem is once they do, the attribute menu assumes "stage" and they no longer have access to the list of sprite properties and variables (because the sprite is unknown until run-time), making the block useless in this scenario.  By presuming you want sprite attributes instead, we can at least provide the default list that is the same for all sprites.  If we also allow reporters to be dropped onto the menu, they could then specify a variable manually without the drop-down.