### PR TITLE
Remove all file extensions when loading a project

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -620,8 +620,12 @@ public class Scratch extends Sprite {
 	}
 
 	public function setProjectName(s:String):void {
-		if (s.slice(-3) == '.sb') s = s.slice(0, -3);
-		if (s.slice(-4) == '.sb2') s = s.slice(0, -4);
+		for (;;) {
+			if (StringUtil.endsWith(s, '.sb')) s = s.slice(0, -3);
+			else if (StringUtil.endsWith(s, '.sb2')) s = s.slice(0, -4);
+			else if (StringUtil.endsWith(s, '.sbx')) s = s.slice(0, -4);
+			else break;
+		}
 		stagePart.setProjectName(s);
 	}
 


### PR DESCRIPTION
When loading a project from a file, remove all instances of '.sb', '.sb2', or '.sbx' found at the end of the file name. Repeat until none remain.

Previous behavior: remove either '.sb' or '.sb2' exactly once. Since this didn't include '.sbx' there are now projects with titles like 'Silly.sbx.sbx.sbx' -- this was the motivation for making this check repeat.

Testing:
- Make sure the projects gets an appropriate title after loading various project files from local disk. For example, all of the following should result in a project title of "Example":
  - [ ] `Example.sb`
  - [ ] `Example.sb2`
  - [ ] `Example.sbx`
  - [ ] `Example.sbx.sbx.sbx`

This resolves LLK/scratchx#32