### PR TITLE
Don't list English twice in the language selector

### DIFF
--- a/src/Scratch.as
+++ b/src/Scratch.as
@@ -620,8 +620,12 @@ public class Scratch extends Sprite {
 	}
 
 	public function setProjectName(s:String):void {
-		if (s.slice(-3) == '.sb') s = s.slice(0, -3);
-		if (s.slice(-4) == '.sb2') s = s.slice(0, -4);
+		for (;;) {
+			if (StringUtil.endsWith(s, '.sb')) s = s.slice(0, -3);
+			else if (StringUtil.endsWith(s, '.sb2')) s = s.slice(0, -4);
+			else if (StringUtil.endsWith(s, '.sbx')) s = s.slice(0, -4);
+			else break;
+		}
 		stagePart.setProjectName(s);
 	}
 

--- a/src/translation/Translator.as
+++ b/src/translation/Translator.as
@@ -46,18 +46,24 @@ public class Translator {
 
 	private static var dictionary:Object = {};
 
+	// Get a list of language names for the languages menu from the server.
 	public static function initializeLanguageList():void {
-		// Get a list of language names for the languages menu from the server.
 		function saveLanguageList(data:String):void {
-			if (!data) return;
-			for each (var line:String in data.split('\n')) {
-				var fields:Array = line.split(',');
-				if (fields.length >= 2) {
-					languages.push([StringUtil.trim(fields[0]), StringUtil.trim(fields[1])]);
+			var newLanguages:Array = [];
+			if (data) {
+				for each (var line:String in data.split('\n')) {
+					var fields:Array = line.split(',');
+					if (fields.length >= 2) {
+						newLanguages.push([StringUtil.trim(fields[0]), StringUtil.trim(fields[1])]);
+					}
 				}
 			}
+			else {
+				// Use English as fallback if we can't get the language list
+				newLanguages.push(['en', 'English']);
+			}
+			languages = newLanguages;
 		}
-		languages = [['en', 'English']]; // English is always the first entry
 		Scratch.app.server.getLanguageList(saveLanguageList);
 	}
 


### PR DESCRIPTION
Previous behavior: Always list English first, then append the languages retrieved from the server. If English is also in that list, then English will be listed twice.

New behavior: Use the language list retrieved from the `lang_list.txt` file exactly. If we fail to load that file, use English as a fallback.

Note that this will affect both the online and offline versions of the editor as well as ScratchX.

This resolves #1210 