### PR TITLE
HTTP/2 compat: use lowercase header field names

### DIFF
--- a/src/util/Server.as
+++ b/src/util/Server.as
@@ -218,12 +218,12 @@ public class Server implements IServer {
 			request.method = URLRequestMethod.POST;
 			request.data = data;
 
-			if (mimeType) request.requestHeaders.push(new URLRequestHeader("Content-type", mimeType));
+			if (mimeType) request.requestHeaders.push(new URLRequestHeader("content-type", mimeType));
 
 			// header for CSRF authentication when sending data
 			var csrfCookie:String = getCSRF();
 			if (csrfCookie && (csrfCookie.length > 0)) {
-				request.requestHeaders.push(new URLRequestHeader('X-CSRFToken', csrfCookie));
+				request.requestHeaders.push(new URLRequestHeader('x-csrftoken', csrfCookie));
 			}
 
 			if (data.length == 0) {


### PR DESCRIPTION
HTTP/2 requires all header field names to be expressed in lowercase.

See LLK/scratch-www#1152. Since this may end up being a high-priority issue, I'd like to consider treating this as part of the January 19th milestone.

/cc @colbygk @jwzimmer