### PR TITLE
Preserve user text for block args in blockToArray

### DIFF
--- a/src/blocks/BlockIO.as
+++ b/src/blocks/BlockIO.as
@@ -72,16 +72,25 @@ public class BlockIO {
 		if (b.op == Specs.PROCEDURE_DEF)								// procedure definition
 			return [Specs.PROCEDURE_DEF, b.spec, b.parameterNames, b.defaultArgValues, b.warpProcFlag];
 		if (b.op == Specs.CALL) result = [Specs.CALL, b.spec];			// procedure call - arguments follow spec
-		for each (var a:* in b.normalizedArgs()) {
-			// Note: arguments are always saved in normalized (i.e. left-to-right) order
-			if (a is Block) result.push(blockToArray(a));
-			if (a is BlockArg) {
-				var argVal:* = BlockArg(a).argValue;
-				if (argVal is ScratchObj) {
+
+		// Note: arguments are always saved in normalized (i.e. left-to-right) order
+		for each (var arg:* in b.normalizedArgs()) {
+			if (arg is Block) {
+				result.push(blockToArray(arg));
+			}
+			else if (arg is BlockArg) {
+				var blockArg:BlockArg = arg as BlockArg;
+				var argText:String;
+				if (blockArg.argValue is ScratchObj) {
+					var scratchObj:ScratchObj = blockArg.argValue as ScratchObj;
 					// convert a Scratch sprite/stage reference to a name string
-					argVal = ScratchObj(argVal).objName;
+					argText = scratchObj.objName;
 				}
-				result.push(argVal);
+				else {
+					// preserve text as-is
+					argText = blockArg.field.text;
+				}
+				result.push(argText);
 			}
 		}
 		if (b.base.canHaveSubstack1()) result.push(stackToArray(b.subStack1));


### PR DESCRIPTION
Before: `blockToArray` returns the parsed value of each block arg
After: `blockToArray` returns the raw text value of each block arg

This means that block arguments should now be preserved by block duplication or save/load cycles.

This resolves #1270