### PR TITLE
Translation: ask extensions for their specs

### DIFF
--- a/src/Specs.as
+++ b/src/Specs.as
@@ -395,7 +395,4 @@ public class Specs {
 		["user id",								"r", 99, "getUserId"],
 
 	];
-
-	public static var extensionSpecs:Array = ["when %m.booleanSensor", "when %m.sensor %m.lessMore %n", "sensor %m.booleanSensor?", "%m.sensor sensor value", "turn %m.motor on for %n secs", "turn %m.motor on", "turn %m.motor off", "set %m.motor power to %n", "set %m.motor2 direction to %m.motorDirection", "when distance %m.lessMore %n", "when tilt %m.eNe %n", "distance", "tilt"];
-
 }}

--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -159,6 +159,31 @@ public class ExtensionManager {
 		}
 	}
 
+	// Retrieve all specs from all loaded extensions. Used by the translation system.
+	// Remember to load all relevant extensions before exporting translation strings!
+	public function getExtensionSpecs():Array {
+		var missingExtensions:Array = [];
+		var specs:Array = [];
+		for (var extName:String in extensionDict) {
+			var ext:ScratchExtension = extensionDict[extName];
+			if (ext.blockSpecs.length > 0) {
+				ext.blockSpecs.forEach(
+						function (fullSpec:Array, ...ignored):void {
+							specs.push(fullSpec[1]);
+						});
+			}
+			else {
+				missingExtensions.push(extName);
+			}
+		}
+		if (missingExtensions.length > 0) {
+			DialogBox.notify(
+					'Missing block specs', 'Block specs were missing for some extensions.\n' +
+					'Please load these extensions and try again:\n' + missingExtensions.join(', '));
+		}
+		return specs;
+	}
+
 	// -----------------------------
 	// Enable/disable/reset
 	//------------------------------

--- a/src/translation/TranslatableStrings.as
+++ b/src/translation/TranslatableStrings.as
@@ -63,7 +63,7 @@ public class TranslatableStrings {
 				if ((spec.length > 0) && (spec.charAt(0) != '-')) add(spec, true);
 			}
 		}
-		addAll(Specs.extensionSpecs);
+		addAll(Scratch.app.extensionManager.getExtensionSpecs());
 		addAll(PaletteSelector.strings());
 		export('commands');
 	}

--- a/src/translation/Translator.as
+++ b/src/translation/Translator.as
@@ -224,7 +224,7 @@ public class Translator {
 
 	private static function checkBlockTranslations():void {
 		for each (var entry:Array in Specs.commands) checkBlockSpec(entry[0]);
-		for each (var spec:String in Specs.extensionSpecs) checkBlockSpec(spec);
+		for each (var spec:String in Scratch.app.extensionManager.getExtensionSpecs()) checkBlockSpec(spec);
 	}
 
 	private static function checkBlockSpec(spec:String):void {


### PR DESCRIPTION
This change removes the hard-coded list of extension specs from `Specs.as`, replacing it with a function on `ExtensionManager` which reads block specs from the actual extensions. This requires the extensions to be loaded, so the function pops up a warning dialog if it detects that any built-in extension is not loaded.

This will be used to resolve LLK/scratchr2#4331