### PR TITLE
Save block arg internal strings when available

### DIFF
--- a/src/blocks/BlockIO.as
+++ b/src/blocks/BlockIO.as
@@ -86,6 +86,11 @@ public class BlockIO {
 					// convert a Scratch sprite/stage reference to a name string
 					argText = scratchObj.objName;
 				}
+				else if (blockArg.argValue is String) {
+					// Preserve drop-down menu values where the field.text is localized. For example:
+					// we want argValue="_mouse_", not field.text which may be "mouse-pointer" or "puntero del ratón"
+					argText = blockArg.argValue;
+				}
 				else {
 					// preserve text as-is
 					argText = blockArg.field.text;


### PR DESCRIPTION
When a block arg's internal storage is a string, save that instead of the field text. This preserves the internal, universal values (like `'_mouse_'`) instead of the localized value (like `'mouse-pointer'` or `'puntero del ratón'`) for selections in drop-down menus.

This resolves LLK/scratch-flash-online#306 which was introduced by #1273 