### PR TITLE
Warn about missing extension specs only on export

### DIFF
--- a/src/extensions/ExtensionManager.as
+++ b/src/extensions/ExtensionManager.as
@@ -161,7 +161,7 @@ public class ExtensionManager {
 
 	// Retrieve all specs from all loaded extensions. Used by the translation system.
 	// Remember to load all relevant extensions before exporting translation strings!
-	public function getExtensionSpecs():Array {
+	public function getExtensionSpecs(warnIfMissing:Boolean):Array {
 		var missingExtensions:Array = [];
 		var specs:Array = [];
 		for (var extName:String in extensionDict) {
@@ -176,7 +176,7 @@ public class ExtensionManager {
 				missingExtensions.push(extName);
 			}
 		}
-		if (missingExtensions.length > 0) {
+		if (warnIfMissing && missingExtensions.length > 0) {
 			DialogBox.notify(
 					'Missing block specs', 'Block specs were missing for some extensions.\n' +
 					'Please load these extensions and try again:\n' + missingExtensions.join(', '));

--- a/src/translation/TranslatableStrings.as
+++ b/src/translation/TranslatableStrings.as
@@ -63,7 +63,7 @@ public class TranslatableStrings {
 				if ((spec.length > 0) && (spec.charAt(0) != '-')) add(spec, true);
 			}
 		}
-		addAll(Scratch.app.extensionManager.getExtensionSpecs());
+		addAll(Scratch.app.extensionManager.getExtensionSpecs(true));
 		addAll(PaletteSelector.strings());
 		export('commands');
 	}

--- a/src/translation/Translator.as
+++ b/src/translation/Translator.as
@@ -224,7 +224,7 @@ public class Translator {
 
 	private static function checkBlockTranslations():void {
 		for each (var entry:Array in Specs.commands) checkBlockSpec(entry[0]);
-		for each (var spec:String in Scratch.app.extensionManager.getExtensionSpecs()) checkBlockSpec(spec);
+		for each (var spec:String in Scratch.app.extensionManager.getExtensionSpecs(false)) checkBlockSpec(spec);
 	}
 
 	private static function checkBlockSpec(spec:String):void {


### PR DESCRIPTION
The new `getExtensionSpecs` method can pop up a warning if one or more built-in extensions are not loaded. This helps avoid problems when exporting strings for translation, but we don't want this warning to pop up when users change their language setting. This change introduces a Boolean argument to control whether or not the warning should pop up.

This resolves #1277 which was introduced by #1274 