### PR TITLE
Handle block arg text for args without text fields

### DIFF
--- a/src/blocks/BlockIO.as
+++ b/src/blocks/BlockIO.as
@@ -80,21 +80,7 @@ public class BlockIO {
 			}
 			else if (arg is BlockArg) {
 				var blockArg:BlockArg = arg as BlockArg;
-				var argText:String;
-				if (blockArg.argValue is ScratchObj) {
-					var scratchObj:ScratchObj = blockArg.argValue as ScratchObj;
-					// convert a Scratch sprite/stage reference to a name string
-					argText = scratchObj.objName;
-				}
-				else if (blockArg.argValue is String) {
-					// Preserve drop-down menu values where the field.text is localized. For example:
-					// we want argValue="_mouse_", not field.text which may be "mouse-pointer" or "puntero del ratón"
-					argText = blockArg.argValue;
-				}
-				else {
-					// preserve text as-is
-					argText = blockArg.field.text;
-				}
+				var argText:String = blockArg.getArgText();
 				result.push(argText);
 			}
 		}


### PR DESCRIPTION
Some blocks -- such as "set color to (color)" -- have a block argument which doesn't use a text field. The code to preserve user text was trying to collect the field text in these cases, resulting in an attempt to access a property of a null reference.

This change does a few things:
- Move the serialization of a `BlockArg`'s value into a method on   `BlockArg` instead of embedding this code into `BlockIO`'s `blockToArray()` function. This is (IMO) a better place for the code in general but also makes it easier to compare `getArgText()` with `setArgValue()`, which deals with similar concepts.
- Add a check to make sure that a block has a text field before trying to collect the text field's value.
- Make the conditions for going with the internal arg value (like `_mouse_`) instead of a potentially localized value (like "puntero del ratón" or "mouse-pointer") more similar to the conditions used by `setArgValue()`.
- Add more comments explaining the intricacies of this code. I have a feeling this stuff will be simpler in 3.0 but I wanted to record the reasoning behind this logic just in case.

This resolves #1283 
See also #1273 and #1278

/cc @jwzimmer 