### PR TITLE
changes the username block warning message to seem less scary

### DIFF
--- a/src/ui/parts/StagePart.as
+++ b/src/ui/parts/StagePart.as
@@ -91,7 +91,7 @@ public class StagePart extends UIPart {
 	public static function strings():Array {
 		return [
 			'by', 'shared', 'unshared', 'Turbo Mode',
-			'This project can detect who is using it, through the “username” block. To hide your identity, sign out before using the project.',
+			'This project uses the “username” block, meaning it can know your username.  Please sign out if you do not want the project to know your username',
 		];
 	}
 
@@ -526,7 +526,7 @@ public class StagePart extends UIPart {
 		userNameWarning.alpha = 0.9;
 
 		const versionFormat:TextFormat = new TextFormat(CSS.font, 16, 0x000000);
-		var userNameWarningText:TextField = makeLabel(Translator.map('This project can detect who is using it, through the “username” block. To hide your identity, sign out before using the project.'), versionFormat, 15, 45);
+		var userNameWarningText:TextField = makeLabel(Translator.map('This project uses the “username” block, meaning it can know your username.  Please sign out if you do not want the project to know your username'), versionFormat, 15, 45);
 		userNameWarningText.width = userNameWarning.width - 10;
 		userNameWarningText.multiline = true;
 		userNameWarningText.wordWrap = true;


### PR DESCRIPTION
on the suggestion https://scratch.mit.edu/discuss/topic/32509/ people didn't like the message that tells people that the project can know their username because it seemed scary. The change I made makes this message seem more safe to parents and the kids on scratch, the text I used was from https://scratch.mit.edu/discuss/topic/32509/?page=11 post 207