### PR TITLE
Drum sample fix

### DIFF
--- a/src/primitives/SoundPrims.as
+++ b/src/primitives/SoundPrims.as
@@ -109,7 +109,11 @@ public class SoundPrims {
 			var drum:int = Math.round(interp.numarg(b, 0));
 			var isMIDI:Boolean = (b.op == 'drum:duration:elapsed:from:');
 			var secs:Number = beatsToSeconds(interp.numarg(b, 1));
-			playDrum(drum, isMIDI, 10, s); // always play entire drum sample
+			var drumDuration:Number = 10; // always play entire drum sample
+			if (secs == 0) {
+    			drumDuration = 0; 
+			}
+			playDrum(drum, isMIDI, drumDuration, s); 
 			interp.startTimer(secs);
 		} else {
 			interp.checkTimer();


### PR DESCRIPTION
Currently, when inside a repeat block, a drum block with "0 beats" re-starts the sound repeatedly with a tiny break in between, rather than not playing at all.

Referenced here: [#1041](https://github.com/LLK/scratch-blocks/issues/1041)

My change will create an exception when a user sets beats to 0. In this case, no sample will be played. 