### PR TITLE
Use `keyCode` instead of ASCII for `primKeyPressed`

### DIFF
--- a/src/primitives/SensingPrims.as
+++ b/src/primitives/SensingPrims.as
@@ -25,6 +25,7 @@
 package primitives {
 	import flash.display.*;
 	import flash.geom.*;
+	import flash.ui.Keyboard;
 	import flash.utils.Dictionary;
 	import blocks.Block;
 	import interpreter.*;
@@ -229,14 +230,16 @@ public class SensingPrims {
 			}
 			return false;
 		}
-		var ch:int = key.charCodeAt(0);
-		if (ch > 127) return false;
-		if (key == 'left arrow') ch = 28;
-		if (key == 'right arrow') ch = 29;
-		if (key == 'up arrow') ch = 30;
-		if (key == 'down arrow') ch = 31;
-		if (key == 'space') ch = 32;
-		return app.runtime.keyIsDown[ch];
+		var ch:int;
+		switch (key) {
+			case 'left arrow': ch = Keyboard.LEFT; break;
+			case 'right arrow': ch = Keyboard.RIGHT; break;
+			case 'up arrow': ch = Keyboard.UP; break;
+			case 'down arrow': ch = Keyboard.DOWN; break;
+			case 'space': ch = Keyboard.SPACE; break;
+			default: ch = key.toUpperCase().charCodeAt(0); break;
+		}
+		return app.runtime.keyIsDown[ch] || false;
 	}
 
 	private function primDistanceTo(b:Block):Number {

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -26,6 +26,8 @@ import assets.Resources;
 import blocks.Block;
 import blocks.BlockArg;
 
+import com.adobe.utils.StringUtil;
+
 import extensions.ExtensionManager;
 
 import flash.display.*;
@@ -68,8 +70,7 @@ public class ScratchRuntime {
 	public var app:Scratch;
 	public var interp:Interpreter;
 	public var motionDetector:VideoMotionPrims;
-	public var keyIsDown:Array = new Array(128); // records key up/down state
-	public var shiftIsDown:Boolean;
+	public var keyIsDown:Array = []; // sparse array recording key up/down state
 	public var lastAnswer:String = '';
 	public var cloneCount:int;
 	public var edgeTriggersEnabled:Boolean = false; // initially false, becomes true when project first run
@@ -557,15 +558,16 @@ public class ScratchRuntime {
 		}
 	}
 
-	public function startKeyHats(ch:int):void {
+	public function startKeyHats(keyCode:int):void {
 		var keyName:String = null;
-		if (('a'.charCodeAt(0) <= ch) && (ch <= 'z'.charCodeAt(0))) keyName = String.fromCharCode(ch);
-		if (('0'.charCodeAt(0) <= ch) && (ch <= '9'.charCodeAt(0))) keyName = String.fromCharCode(ch);
-		if (28 == ch) keyName = 'left arrow';
-		if (29 == ch) keyName = 'right arrow';
-		if (30 == ch) keyName = 'up arrow';
-		if (31 == ch) keyName = 'down arrow';
-		if (32 == ch) keyName = 'space';
+		switch (keyCode) {
+			case Keyboard.LEFT: keyName = 'left arrow'; break;
+			case Keyboard.RIGHT: keyName = 'right arrow'; break;
+			case Keyboard.UP: keyName = 'up arrow'; break;
+			case Keyboard.DOWN: keyName = 'down arrow'; break;
+			case Keyboard.SPACE: keyName = 'space'; break;
+			default: keyName = String.fromCharCode(keyCode).toLowerCase(); break;
+		}
 		function startMatchingKeyHats(stack:Block, target:ScratchObj):void {
 			if (stack.op == 'whenKeyPressed') {
 				var k:String = stack.args[0].argValue;
@@ -947,40 +949,50 @@ public class ScratchRuntime {
 	// Keyboard input handling
 	//------------------------------
 
+	public function get shiftIsDown():Boolean {
+		return keyIsDown[Keyboard.SHIFT];
+	}
+
+	// see BitmapEdit.cropToSelection()
+	public function set shiftIsDown(value:Boolean):void {
+		keyIsDown[Keyboard.SHIFT] = value;
+	}
+
 	public function keyDown(evt:KeyboardEvent):void {
-		shiftIsDown = evt.shiftKey;
 		var ch:int = getCharCode(evt);
 		if (!(evt.target is TextField)) startKeyHats(ch);
-		if (ch < 128) keyIsDown[ch] = true;
+		keyIsDown[ch] = true;
 	}
 
 	public function keyUp(evt:KeyboardEvent):void {
-		shiftIsDown = evt.shiftKey;
 		var ch:int = getCharCode(evt);
-		if (ch < 128) keyIsDown[ch] = false;
+		delete keyIsDown[ch];
 	}
 
 	private function clearKeyDownArray():void {
-		for (var i:int = 0; i < 128; i++) keyIsDown[i] = false;
+		keyIsDown.length = 0;
 	}
 
-	// Get an ASCII value for the key pressed:
-	// - Latin letters will be normalized to lower-case
-	// - Arrows will be mapped to ASCII/Unicode delimiters (this is a traditional hack in Scratch 2.0; see mapArrowKey)
+	// Get a normalized "ASCII" value for the keyCode pressed:
+	// - Number keys on the numeric keypad will be mapped to ASCII digits
+	// - Other keyCodes will pass through as-is. This means:
+	//   - Letter keys will return the upper-case ASCII value (note: lower-case ASCII overlaps with other keyCodes)
+	//   - Number keys not on the numeric keypad will return the ASCII value of the corresponding digit
+	//   - Other keys (for example, arrows) will have meaningless but unique ASCII codes, useful for "any" key detection
 	private static function getCharCode(evt:KeyboardEvent):int {
-		var arrowCode:int = mapArrowKey(evt.keyCode);
-		if (arrowCode) return arrowCode;
-		return String.fromCharCode(evt.keyCode).toLowerCase().charCodeAt(0);
-	}
-
-	// Map key codes for arrow keys to ASCII delimiters, and other key codes to zero.
-	// See https://en.wikipedia.org/wiki/Delimiter#ASCII_delimited_text
-	private static function mapArrowKey(keyCode:int):int {
-		if (keyCode == Keyboard.LEFT) return 28; // file separator
-		if (keyCode == Keyboard.UP) return 30; // group separator
-		if (keyCode == Keyboard.RIGHT) return 29; // record separator
-		if (keyCode == Keyboard.DOWN) return 31; // unit separator
-		return 0;
+		switch (evt.keyCode) {
+			case Keyboard.NUMPAD_0: return Keyboard.NUMBER_0;
+			case Keyboard.NUMPAD_1: return Keyboard.NUMBER_1;
+			case Keyboard.NUMPAD_2: return Keyboard.NUMBER_2;
+			case Keyboard.NUMPAD_3: return Keyboard.NUMBER_3;
+			case Keyboard.NUMPAD_4: return Keyboard.NUMBER_4;
+			case Keyboard.NUMPAD_5: return Keyboard.NUMBER_5;
+			case Keyboard.NUMPAD_6: return Keyboard.NUMBER_6;
+			case Keyboard.NUMPAD_7: return Keyboard.NUMBER_7;
+			case Keyboard.NUMPAD_8: return Keyboard.NUMBER_8;
+			case Keyboard.NUMPAD_9: return Keyboard.NUMBER_9;
+			default: return evt.keyCode;
+		}
 	}
 
 	// -----------------------------


### PR DESCRIPTION
The `keyIsDown` array now tracks keys by their normalized `keyCode` rather than ASCII value. This means that in situations where we don't get a good `charCode` (see #1334) we can still track a key without worrying about mapping its `keyCode` to an ASCII value. That mapping is straightforward for some keys (letters, for example) but not for others (comma, for example).

This change is the result of a problem that @tarmelop noticed with #1341 where certain keys would work for the `when {any} key pressed` hat block but would not work for the `is {any} key pressed?` reporter. These are keys like the comma, where the `keyCode` value doesn't match the character's ASCII value -- this was the key oversight with #1341. Also, the `keyCode` value for some such keys is larger than 127, so that restriction has been removed from the `keyIsDown` handling.

## Testing

This code is currently available for testing on my dev port (cwillisf).

Put code like this on the default cat:
![image](https://user-images.githubusercontent.com/7019101/29533728-13c9a4c4-8668-11e7-8bba-51bb89d36fde.png)

If you press and hold the key indicated, then the cat should:
- Repeatedly move its legs (costume change), and
- Rotate once, delay (key repeat delay), then repeatedly spin in place.

Overall this makes it look like the cat starts running in place, then gets traction and starts running in circles. I believe "cartoon run" is the technical term for this behavior. 🤓

Note that Edge sometimes caches the SWF even through a "hard" reload. I recommend visiting a page other than the editor page then clearing the cache before testing. Clear the cache by opening the "..." menu, picking "Settings", "Choose what to clear", and then "Clear" with at least "Cached data and files" checked.

Test with at least the following keys:
- The 'space' key
  - [ ] cartoon run works
- At least one arrow key
  - [ ] cartoon run works
- At least one letter key
  - [ ] cartoon run works
  - [ ] modifier states don't matter (shift, caps lock)
- At least one number key
  - [ ] regular number key causes cartoon run
  - [ ] numeric keypad number key causes cartoon run (check numlock)
- 'any' key
  - [ ] space key causes cartoon run
  - [ ] arrow key causes cartoon run
  - [ ] letter key causes cartoon run
  - [ ] regular number key causes cartoon run
  - [ ] numeric keypad number key causes cartoon run
  - [ ] comma key causes cartoon run
