### PR TITLE
Pseudo-revert keypress changes

### DIFF
--- a/src/primitives/SensingPrims.as
+++ b/src/primitives/SensingPrims.as
@@ -25,7 +25,6 @@
 package primitives {
 	import flash.display.*;
 	import flash.geom.*;
-	import flash.ui.Keyboard;
 	import flash.utils.Dictionary;
 	import blocks.Block;
 	import interpreter.*;
@@ -230,16 +229,14 @@ public class SensingPrims {
 			}
 			return false;
 		}
-		var ch:int;
-		switch (key) {
-			case 'left arrow': ch = Keyboard.LEFT; break;
-			case 'right arrow': ch = Keyboard.RIGHT; break;
-			case 'up arrow': ch = Keyboard.UP; break;
-			case 'down arrow': ch = Keyboard.DOWN; break;
-			case 'space': ch = Keyboard.SPACE; break;
-			default: ch = key.toUpperCase().charCodeAt(0); break;
-		}
-		return app.runtime.keyIsDown[ch] || false;
+		var ch:int = key.charCodeAt(0);
+		if (ch > 127) return false;
+		if (key == 'left arrow') ch = 28;
+		if (key == 'right arrow') ch = 29;
+		if (key == 'up arrow') ch = 30;
+		if (key == 'down arrow') ch = 31;
+		if (key == 'space') ch = 32;
+		return app.runtime.keyIsDown[ch];
 	}
 
 	private function primDistanceTo(b:Block):Number {

--- a/src/primitives/SensingPrims.as
+++ b/src/primitives/SensingPrims.as
@@ -229,14 +229,8 @@ public class SensingPrims {
 			}
 			return false;
 		}
-		var ch:int = key.charCodeAt(0);
-		if (ch > 127) return false;
-		if (key == 'left arrow') ch = 28;
-		if (key == 'right arrow') ch = 29;
-		if (key == 'up arrow') ch = 30;
-		if (key == 'down arrow') ch = 31;
-		if (key == 'space') ch = 32;
-		return app.runtime.keyIsDown[ch];
+		var ch:int = ScratchRuntime.getKeyCode(key);
+		return app.runtime.keyIsDown[ch] || false;
 	}
 
 	private function primDistanceTo(b:Block):Number {

--- a/src/scratch/ScratchRuntime.as
+++ b/src/scratch/ScratchRuntime.as
@@ -37,7 +37,6 @@ import flash.media.*;
 import flash.net.*;
 import flash.system.System;
 import flash.text.TextField;
-import flash.ui.Keyboard;
 import flash.utils.*;
 
 import interpreter.*;
@@ -949,14 +948,18 @@ public class ScratchRuntime {
 
 	public function keyDown(evt:KeyboardEvent):void {
 		shiftIsDown = evt.shiftKey;
-		var ch:int = getCharCode(evt);
+		var ch:int = evt.charCode;
+		if (evt.charCode == 0) ch = mapArrowKey(evt.keyCode);
+		if ((65 <= ch) && (ch <= 90)) ch += 32; // map A-Z to a-z
 		if (!(evt.target is TextField)) startKeyHats(ch);
 		if (ch < 128) keyIsDown[ch] = true;
 	}
 
 	public function keyUp(evt:KeyboardEvent):void {
 		shiftIsDown = evt.shiftKey;
-		var ch:int = getCharCode(evt);
+		var ch:int = evt.charCode;
+		if (evt.charCode == 0) ch = mapArrowKey(evt.keyCode);
+		if ((65 <= ch) && (ch <= 90)) ch += 32; // map A-Z to a-z
 		if (ch < 128) keyIsDown[ch] = false;
 	}
 
@@ -964,22 +967,12 @@ public class ScratchRuntime {
 		for (var i:int = 0; i < 128; i++) keyIsDown[i] = false;
 	}
 
-	// Get an ASCII value for the key pressed:
-	// - Latin letters will be normalized to lower-case
-	// - Arrows will be mapped to ASCII/Unicode delimiters (this is a traditional hack in Scratch 2.0; see mapArrowKey)
-	private static function getCharCode(evt:KeyboardEvent):int {
-		var arrowCode:int = mapArrowKey(evt.keyCode);
-		if (arrowCode) return arrowCode;
-		return String.fromCharCode(evt.keyCode).toLowerCase().charCodeAt(0);
-	}
-
-	// Map key codes for arrow keys to ASCII delimiters, and other key codes to zero.
-	// See https://en.wikipedia.org/wiki/Delimiter#ASCII_delimited_text
-	private static function mapArrowKey(keyCode:int):int {
-		if (keyCode == Keyboard.LEFT) return 28; // file separator
-		if (keyCode == Keyboard.UP) return 30; // group separator
-		if (keyCode == Keyboard.RIGHT) return 29; // record separator
-		if (keyCode == Keyboard.DOWN) return 31; // unit separator
+	private function mapArrowKey(keyCode:int):int {
+		// map key codes for arrow keys to ASCII, other key codes to zero
+		if (keyCode == 37) return 28;
+		if (keyCode == 38) return 30;
+		if (keyCode == 39) return 29;
+		if (keyCode == 40) return 31;
 		return 0;
 	}
 


### PR DESCRIPTION
This resolves #1361 to the extent that we can. Note that #1361 is `prio-critical` so this could be a candidate for a hotfix, or maybe just late inclusion into the current freeze? CC @jwzimmer

It may also be interesting to compare this code to the code we had before #1341. You can simulate this by just looking at the last commit: 807e2b0e3cc133f3c5d449a7fc82437678313cde

Edge has fixed their `charCode` bug, so we don't need to work around it any more; this change starts off by reverting #1341 and #1345. However, I felt that some of the changes I made for the workaround were worth keeping. This code should have the same observable behavior as the pre-Edge-fix code, but logic related to keyboard events and key codes & names is centralized and better documented. Hopefully this will make this a more useful reference as we run into edge cases and quirks in Scratch 3.0...

Note that there still seem to be bugs in Edge: sometimes keys can become "stuck" for a little while, and keyboard response seems generally a bit slower than in other browsers. I've verified that these issues affect other Flash apps so I don't think there's anything we can do about it.

Testing:
In several different browsers, including Edge:
- Load & run my "keyscan" test project (182455392 from production or rename [this ZIP](https://github.com/LLK/scratch-flash/files/1423352/keyscan.zip) to end in SB2)
  - While a key is held it should appear in the "key pressed?" list, and the last few keys pressed should be listed in the "when key" list.
- Verify that several different types of key work as expected (here's an [ASCII table](https://en.wikipedia.org/wiki/ASCII#Printable_characters) in case it helps):
  - [ ] letters
  - [ ] numbers
  - [ ] punctuation & other symbols (like `[` or `/`)
  - [ ] space (32) & tab (9)
- Load & run "Tale of the Fiery Dragon v1.5c" by Griffpatch (126517840 from production)
  - Click past the initial screen of text
  - [ ] Verify that the text prompt works as expected

Note: it might help to compare behavior with scratchx.org, which is currently using a version of the editor from before #1341.